### PR TITLE
journal: add initial refresh support and paging

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -92,6 +92,9 @@ dependencies {
     implementation(libs.moshi.converter)
     ksp(libs.moshi.kotlin.codegen)
 
+    implementation(libs.paging.runtime)
+    implementation(libs.paging.compose)
+
     implementation(libs.retrofit)
     debugImplementation(libs.okhttp.logging.interceptor)
 

--- a/app/src/main/java/com/teobaranga/monica/data/sync/Synchronizer.kt
+++ b/app/src/main/java/com/teobaranga/monica/data/sync/Synchronizer.kt
@@ -1,0 +1,10 @@
+package com.teobaranga.monica.data.sync
+
+interface Synchronizer {
+    suspend fun sync()
+
+    enum class State {
+        IDLE,
+        REFRESHING,
+    }
+}

--- a/app/src/main/java/com/teobaranga/monica/journal/JournalScreen.kt
+++ b/app/src/main/java/com/teobaranga/monica/journal/JournalScreen.kt
@@ -12,8 +12,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -22,11 +26,20 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
 import com.ramcosta.composedestinations.annotation.Destination
+import com.teobaranga.monica.dashboard.DashboardSearchBar
+import com.teobaranga.monica.journal.model.JournalEntry
+import com.teobaranga.monica.ui.avatar.UserAvatar
 import com.teobaranga.monica.ui.plus
 
 @JournalNavGraph(start = true)
@@ -34,56 +47,116 @@ import com.teobaranga.monica.ui.plus
 @Composable
 fun Journal() {
     val viewModel = hiltViewModel<JournalViewModel>()
-    val uiState by viewModel.uiState.collectAsState()
-    when (val uiState = uiState) {
-        null -> {
-            // TODO: shimmer
-            Box(modifier = Modifier.fillMaxSize())
-        }
-        else -> {
-            JournalScreen(
-                uiState = uiState,
-            )
-        }
-    }
+    val userAvatar by viewModel.userAvatar.collectAsState()
+    val lazyItems = viewModel.items.collectAsLazyPagingItems()
+    val isRefreshing by viewModel.isRefreshing.collectAsState()
+    JournalScreen(
+        userAvatar = userAvatar,
+        lazyItems = lazyItems,
+        onAvatarClick = {
+            // TODO
+        },
+        isRefreshing = isRefreshing,
+        onRefresh = {
+            viewModel.refresh()
+        },
+    )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
 @Composable
 fun JournalScreen(
-    uiState: JournalUiState,
+    userAvatar: UserAvatar?,
+    onAvatarClick: () -> Unit,
+    lazyItems: LazyPagingItems<JournalEntry>,
+    isRefreshing: Boolean,
+    onRefresh: () -> Unit,
 ) {
-    LazyColumn(
+    val colors = arrayOf(
+        0.0f to MaterialTheme.colorScheme.background.copy(alpha = 0.78f),
+        0.75f to MaterialTheme.colorScheme.background.copy(alpha = 0.78f),
+        1.0f to MaterialTheme.colorScheme.background.copy(alpha = 0.0f),
+    )
+    if (userAvatar != null) {
+        DashboardSearchBar(
+            modifier = Modifier
+                .background(Brush.verticalGradient(colorStops = colors))
+                .statusBarsPadding()
+                .padding(top = 16.dp, bottom = 20.dp),
+            userAvatar = userAvatar,
+            onAvatarClick = onAvatarClick,
+        )
+    }
+    val pullRefreshState = rememberPullRefreshState(
+        refreshing = isRefreshing,
+        onRefresh = onRefresh,
+    )
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .statusBarsPadding()
+            .padding(top = SearchBarDefaults.InputFieldHeight + 20.dp)
+            .zIndex(2f)
+    ) {
+        PullRefreshIndicator(
+            modifier = Modifier
+                .align(Alignment.TopCenter),
+            refreshing = isRefreshing,
+            state = pullRefreshState,
+        )
+    }
+    Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-        contentPadding = WindowInsets.statusBars.asPaddingValues() + PaddingValues(
-            top = SearchBarDefaults.InputFieldHeight + 36.dp,
-            bottom = 20.dp,
-        ),
+            .pullRefresh(pullRefreshState),
     ) {
-        items(
-            items = uiState.entries,
-            key = { it.id },
-        ) { journalEntry ->
-            Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 20.dp),
-                onClick = {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = WindowInsets.statusBars.asPaddingValues() + PaddingValues(
+                top = SearchBarDefaults.InputFieldHeight + 36.dp,
+                bottom = 20.dp,
+            ),
+        ) {
+            when (lazyItems.loadState.refresh) {
+                is LoadState.Error -> {
                     // TODO
-                },
-            ) {
-                Column(
-                    modifier = Modifier
-                        .padding(16.dp),
-                ) {
-                    Text(
-                        text = journalEntry.post,
-                        maxLines = 5,
-                        overflow = TextOverflow.Ellipsis,
-                    )
+                }
+
+                is LoadState.Loading,
+                is LoadState.NotLoading -> {
+                    items(
+                        count = lazyItems.itemCount,
+                        key = {
+                            val journalEntry = lazyItems[it]
+                            journalEntry?.id ?: Int.MIN_VALUE
+                        },
+                    ) {
+                        val journalEntry = lazyItems[it]
+                        if (journalEntry != null) {
+                            Card(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 20.dp),
+                                onClick = {
+                                    // TODO
+                                },
+                            ) {
+                                Column(
+                                    modifier = Modifier
+                                        .padding(16.dp),
+                                ) {
+                                    Text(
+                                        text = journalEntry.post,
+                                        maxLines = 5,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/teobaranga/monica/journal/JournalViewModel.kt
+++ b/app/src/main/java/com/teobaranga/monica/journal/JournalViewModel.kt
@@ -2,29 +2,73 @@ package com.teobaranga.monica.journal
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.cachedIn
+import com.teobaranga.monica.contacts.userAvatar
+import com.teobaranga.monica.data.sync.Synchronizer
+import com.teobaranga.monica.data.user.UserRepository
 import com.teobaranga.monica.journal.data.JournalRepository
+import com.teobaranga.monica.journal.data.JournalSynchronizer
+import com.teobaranga.monica.user.userAvatar
+import com.teobaranga.monica.util.coroutines.Dispatcher
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
+
+private const val PAGE_SIZE = 15
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
-class JournalViewModel @Inject constructor(
-    journalRepository: JournalRepository,
+internal class JournalViewModel @Inject constructor(
+    private val dispatcher: Dispatcher,
+    userRepository: UserRepository,
+    private val journalRepository: JournalRepository,
+    private val journalSynchronizer: JournalSynchronizer,
 ) : ViewModel() {
 
-    val uiState = journalRepository.getJournalEntries(orderBy = JournalRepository.OrderBy.Date(isAscending = false))
-        .mapLatest { journalEntries ->
-            JournalUiState(
-                entries = journalEntries,
-            )
+    val userAvatar = userRepository.me
+        .mapLatest { me ->
+            me.contact?.userAvatar ?: me.userAvatar
         }
         .stateIn(
             scope = viewModelScope,
             initialValue = null,
             started = SharingStarted.WhileSubscribed(5_000),
         )
+
+    val items = Pager(
+        config = PagingConfig(pageSize = PAGE_SIZE, enablePlaceholders = false),
+        pagingSourceFactory = {
+            journalRepository.getJournalEntries(
+                orderBy = JournalRepository.OrderBy.Date(isAscending = false),
+            )
+        },
+    )
+        .flow
+        .cachedIn(viewModelScope)
+
+    val isRefreshing = journalSynchronizer.syncState
+        .mapLatest { state ->
+            state == Synchronizer.State.REFRESHING
+        }
+        .stateIn(
+            scope = viewModelScope,
+            initialValue = false,
+            started = SharingStarted.WhileSubscribed(5_000),
+        )
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        viewModelScope.launch(dispatcher.io) {
+            journalSynchronizer.sync()
+        }
+    }
 }

--- a/app/src/main/java/com/teobaranga/monica/journal/data/JournalPagingSource.kt
+++ b/app/src/main/java/com/teobaranga/monica/journal/data/JournalPagingSource.kt
@@ -1,0 +1,86 @@
+package com.teobaranga.monica.journal.data
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.teobaranga.monica.data.sync.Synchronizer
+import com.teobaranga.monica.database.OrderBy
+import com.teobaranga.monica.journal.database.JournalDao
+import com.teobaranga.monica.journal.database.toExternalModel
+import com.teobaranga.monica.journal.model.JournalEntry
+import com.teobaranga.monica.util.coroutines.Dispatcher
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.reduce
+import kotlinx.coroutines.launch
+
+
+private const val STARTING_KEY = 0
+
+internal class JournalPagingSource @AssistedInject constructor(
+    dispatcher: Dispatcher,
+    private val journalDao: JournalDao,
+    private val journalSynchronizer: JournalSynchronizer,
+    @Assisted
+    private val orderBy: JournalRepository.OrderBy,
+) : PagingSource<Int, JournalEntry>() {
+
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher.io)
+
+    init {
+        scope.launch {
+            journalSynchronizer.syncState
+                .reduce { prev, new ->
+                    if (prev == Synchronizer.State.REFRESHING && new == Synchronizer.State.IDLE) {
+                        scope.cancel()
+                        invalidate()
+                    }
+                    new
+                }
+        }
+    }
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, JournalEntry> {
+        // Start paging with the STARTING_KEY if this is the first load
+        val start = params.key ?: STARTING_KEY
+
+        val entries = getEntries(start, params)
+
+        return LoadResult.Page(
+            data = entries,
+            // Make sure we don't try to load items behind the STARTING_KEY
+            prevKey = if (start == 0) null else start - 1,
+            nextKey = if (entries.isEmpty()) null else start + 1,
+        )
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, JournalEntry>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            val anchorPage = state.closestPageToPosition(anchorPosition)
+            anchorPage?.prevKey?.plus(1) ?: anchorPage?.nextKey?.minus(1)
+        }
+    }
+
+    private suspend fun getEntries(start: Int, params: LoadParams<Int>): List<JournalEntry> {
+        return journalDao.getJournalEntries(
+            orderBy = with(orderBy) { OrderBy(columnName, isAscending) },
+            limit = params.loadSize,
+            offset = start * params.loadSize,
+        ).map { journalEntryEntities ->
+            journalEntryEntities.map {
+                it.toExternalModel()
+            }
+        }.first()
+    }
+
+
+    @AssistedFactory
+    internal interface Factory {
+        fun create(orderBy: JournalRepository.OrderBy): JournalPagingSource
+    }
+}

--- a/app/src/main/java/com/teobaranga/monica/journal/data/JournalRepository.kt
+++ b/app/src/main/java/com/teobaranga/monica/journal/data/JournalRepository.kt
@@ -1,94 +1,23 @@
 package com.teobaranga.monica.journal.data
 
-import com.skydoves.sandwich.ApiResponse
-import com.skydoves.sandwich.getOrNull
-import com.skydoves.sandwich.onFailure
-import com.teobaranga.monica.database.OrderBy
 import com.teobaranga.monica.journal.database.JournalDao
-import com.teobaranga.monica.journal.database.JournalEntryEntity
 import com.teobaranga.monica.journal.database.toExternalModel
 import com.teobaranga.monica.journal.model.JournalEntry
-import com.teobaranga.monica.util.coroutines.Dispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.mapLatest
-import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
+import javax.inject.Provider
 import javax.inject.Singleton
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @Singleton
-class JournalRepository @Inject constructor(
-    private val dispatcher: Dispatcher,
-    private val journalApi: JournalApi,
+internal class JournalRepository @Inject constructor(
     private val journalDao: JournalDao,
+    private val pagingSource: Provider<JournalPagingSource.Factory>,
 ) {
-    private val scope = CoroutineScope(SupervisorJob() + dispatcher.io)
-
-    private var needsSync: Boolean = true
-
-    private fun syncJournal(orderBy: OrderBy? = null) {
-        if (!needsSync) {
-            return
-        }
-        needsSync = false
-        scope.launch(dispatcher.io) {
-            val sort = when (orderBy) {
-                is OrderBy.Updated -> {
-                    buildString {
-                        if (!orderBy.isAscending) {
-                            append("-")
-                        }
-                        append("updated_at")
-                    }
-                }
-                is OrderBy.Date -> {
-                    buildString {
-                        if (!orderBy.isAscending) {
-                            append("-")
-                        }
-                        append("date")
-                    }
-                }
-
-                null -> null
-            }
-
-            var nextPage: Int? = 1
-            while (nextPage != null) {
-                val journalEntriesResponse = journalApi.getJournal(page = nextPage, sort = sort)
-                    .onFailure {
-                        Timber.w("Error while loading journal: %s", this)
-                        (this as ApiResponse.Failure.Exception).exception
-                    }
-                    .getOrNull() ?: return@launch
-                val contacts = journalEntriesResponse.data
-                    .map(::mapResponse)
-                journalDao.upsertJournalEntries(contacts)
-
-                journalEntriesResponse.meta.run {
-                    nextPage = if (currentPage != lastPage) {
-                        currentPage + 1
-                    } else {
-                        null
-                    }
-                }
-            }
-        }
-    }
-
-    fun getJournalEntries(orderBy: OrderBy? = null): Flow<List<JournalEntry>> {
-        syncJournal()
-        return journalDao.getJournalEntries(orderBy = orderBy?.let { OrderBy(it.columnName, it.isAscending) })
-            .mapLatest { journalEntries ->
-                journalEntries
-                    .map {
-                        it.toExternalModel()
-                    }
-            }
+    fun getJournalEntries(orderBy: OrderBy): JournalPagingSource {
+        return pagingSource.get().create(orderBy)
     }
 
     fun getJournalEntry(id: Int): Flow<JournalEntry> {
@@ -96,19 +25,6 @@ class JournalRepository @Inject constructor(
             .mapLatest {
                 it.toExternalModel()
             }
-    }
-
-    private fun mapResponse(response: JournalEntryResponse): JournalEntryEntity {
-        return JournalEntryEntity(
-            id = response.id,
-            uuid = response.uuid,
-            accountId = response.account.id,
-            title = response.title,
-            post = response.post,
-            date = response.date,
-            created = response.created,
-            updated = response.updated,
-        )
     }
 
     sealed interface OrderBy {

--- a/app/src/main/java/com/teobaranga/monica/journal/data/JournalSynchronizer.kt
+++ b/app/src/main/java/com/teobaranga/monica/journal/data/JournalSynchronizer.kt
@@ -1,0 +1,71 @@
+package com.teobaranga.monica.journal.data
+
+import com.skydoves.sandwich.getOrNull
+import com.skydoves.sandwich.onFailure
+import com.teobaranga.monica.data.sync.Synchronizer
+import com.teobaranga.monica.journal.database.JournalDao
+import com.teobaranga.monica.journal.database.JournalEntryEntity
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class JournalSynchronizer @Inject constructor(
+    private val journalApi: JournalApi,
+    private val journalDao: JournalDao,
+): Synchronizer {
+
+    val syncState = MutableStateFlow(Synchronizer.State.IDLE)
+
+    override suspend fun sync() {
+        syncState.value = Synchronizer.State.REFRESHING
+
+        // Keep track of removed journal entries, start with the full database first
+        val removedIds = journalDao.getJournalEntryIds().first().toMutableSet()
+
+        var nextPage: Int? = 1
+        while (nextPage != null) {
+            val journalEntriesResponse = journalApi.getJournal(page = nextPage, sort = "-updated_at")
+                .onFailure {
+                    Timber.w("Error while loading journal: %s", this)
+                }
+                .getOrNull() ?: break
+            val journalEntries = journalEntriesResponse.data
+                .map {
+                    it.toEntity()
+                }
+
+            journalDao.upsertJournalEntries(journalEntries)
+
+            journalEntriesResponse.meta.run {
+                nextPage = if (currentPage != lastPage) {
+                    currentPage + 1
+                } else {
+                    null
+                }
+            }
+
+            // Reduce the list of entries to be removed based on the entries previously inserted
+            removedIds -= journalEntries.map { it.id }.toSet()
+        }
+
+        journalDao.delete(removedIds.toList())
+
+        syncState.value = Synchronizer.State.IDLE
+    }
+    
+    private fun JournalEntryResponse.toEntity(): JournalEntryEntity {
+        return JournalEntryEntity(
+            id = id,
+            uuid = uuid,
+            accountId = account.id,
+            title = title,
+            post = post,
+            date = date,
+            created = created,
+            updated = updated,
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ kotlinx-coroutines-test = "1.7.3"
 moshi = "1.15.0"
 moshi-converter = "2.9.0"
 okhttp = "4.12.0"
+paging = "3.2.1"
 retrofit = "2.9.0"
 room = "2.6.0"
 sandwich = "1.3.9"
@@ -44,6 +45,8 @@ moshi-adapters = { group = "com.squareup.moshi", name = "moshi-adapters", versio
 moshi-converter = { group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "moshi-converter" }
 moshi-kotlin-codegen = { group = "com.squareup.moshi", name = "moshi-kotlin-codegen", version.ref = "moshi" }
 okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
+paging-runtime = { group = "androidx.paging", name = "paging-runtime", version.ref = "paging" }
+paging-compose = { group = "androidx.paging", name = "paging-compose", version.ref = "paging" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }


### PR DESCRIPTION
Due to the potentially large number of journal entries, the Paging library is introduced to avoid holding too many entries in memory.

The `JournalPagingSource` is responsible for grabbing the correct pages of data from Room. It also observes the refresh status and invalidates itself after a refresh event.

The synchronization is done on the first load of the journal screen and then only on demand.