### PR TITLE
Modernise Compose Destinations & Material 3 components

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,7 +86,6 @@ dependencies {
     implementation(libs.ui)
     implementation(libs.ui.graphics)
     implementation(libs.ui.tooling.preview)
-    implementation(libs.material)
     implementation(libs.material3)
     implementation(libs.androidx.compose.material.icons)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -99,6 +99,7 @@ dependencies {
     implementation(libs.coil)
 
     implementation(libs.compose.destinations.core)
+    implementation(libs.compose.destinations.bottom.sheet)
     ksp(libs.compose.destinations.ksp)
 
     implementation(libs.datastore.preferences)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -99,7 +99,6 @@ dependencies {
     implementation(libs.coil)
 
     implementation(libs.compose.destinations.core)
-    implementation(libs.compose.destinations.bottom.sheet)
     ksp(libs.compose.destinations.ksp)
 
     implementation(libs.datastore.preferences)

--- a/app/src/main/java/com/teobaranga/monica/MainActivity.kt
+++ b/app/src/main/java/com/teobaranga/monica/MainActivity.kt
@@ -4,29 +4,22 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.navigation.BottomSheetNavigator
+import androidx.compose.material.navigation.ModalBottomSheetLayout
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.navigation.plusAssign
-import com.google.accompanist.navigation.material.BottomSheetNavigator
-import com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi
-import com.google.accompanist.navigation.material.ModalBottomSheetLayout
 import com.ramcosta.composedestinations.DestinationsNavHost
-import com.ramcosta.composedestinations.animations.rememberAnimatedNavHostEngine
+import com.ramcosta.composedestinations.generated.NavGraphs
+import com.ramcosta.composedestinations.rememberNavHostEngine
 import com.teobaranga.monica.ui.theme.MonicaTheme
 import dagger.hilt.android.AndroidEntryPoint
 
-@OptIn(
-    ExperimentalMaterialNavigationApi::class,
-    ExperimentalAnimationApi::class,
-    ExperimentalMaterialApi::class,
-)
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -42,7 +35,7 @@ class MainActivity : ComponentActivity() {
                         skipHalfExpanded = true,
                     )
                     val bottomSheetNavigator = remember { BottomSheetNavigator(sheetState) }
-                    val engine = rememberAnimatedNavHostEngine()
+                    val engine = rememberNavHostEngine()
                     val navController = engine.rememberNavController()
                     navController.navigatorProvider += bottomSheetNavigator
 

--- a/app/src/main/java/com/teobaranga/monica/MainActivity.kt
+++ b/app/src/main/java/com/teobaranga/monica/MainActivity.kt
@@ -5,18 +5,9 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.ModalBottomSheetValue
-import androidx.compose.material.navigation.BottomSheetNavigator
-import androidx.compose.material.navigation.ModalBottomSheetLayout
-import androidx.compose.material.rememberModalBottomSheetState
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
-import androidx.navigation.plusAssign
 import com.ramcosta.composedestinations.DestinationsNavHost
 import com.ramcosta.composedestinations.generated.NavGraphs
-import com.ramcosta.composedestinations.rememberNavHostEngine
 import com.teobaranga.monica.ui.theme.MonicaTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -30,28 +21,11 @@ class MainActivity : ComponentActivity() {
                 dynamicColor = false,
             ) {
                 MonicaBackground {
-                    val sheetState = rememberModalBottomSheetState(
-                        initialValue = ModalBottomSheetValue.Hidden,
-                        skipHalfExpanded = true,
+                    DestinationsNavHost(
+                        modifier = Modifier
+                            .fillMaxSize(),
+                        navGraph = NavGraphs.root,
                     )
-                    val bottomSheetNavigator = remember { BottomSheetNavigator(sheetState) }
-                    val engine = rememberNavHostEngine()
-                    val navController = engine.rememberNavController()
-                    navController.navigatorProvider += bottomSheetNavigator
-
-                    ModalBottomSheetLayout(
-                        bottomSheetNavigator = bottomSheetNavigator,
-                        sheetBackgroundColor = Color.Transparent,
-                        sheetElevation = 0.dp,
-                    ) {
-                        DestinationsNavHost(
-                            modifier = Modifier
-                                .fillMaxSize(),
-                            navGraph = NavGraphs.root,
-                            engine = engine,
-                            navController = navController,
-                        )
-                    }
                 }
             }
         }

--- a/app/src/main/java/com/teobaranga/monica/account/Account.kt
+++ b/app/src/main/java/com/teobaranga/monica/account/Account.kt
@@ -18,11 +18,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.ramcosta.composedestinations.annotation.Destination
-import com.ramcosta.composedestinations.spec.DestinationStyleBottomSheet
+import com.ramcosta.composedestinations.annotation.RootGraph
+import com.ramcosta.composedestinations.bottomsheet.spec.DestinationStyleBottomSheet
 import com.teobaranga.monica.ui.PreviewPixel4
 import com.teobaranga.monica.ui.theme.MonicaTheme
 
-@Destination(style = DestinationStyleBottomSheet::class)
+@Destination<RootGraph>(style = DestinationStyleBottomSheet::class)
 @Composable
 fun ColumnScope.Account() {
     val viewModel = hiltViewModel<AccountViewModel>()

--- a/app/src/main/java/com/teobaranga/monica/account/Account.kt
+++ b/app/src/main/java/com/teobaranga/monica/account/Account.kt
@@ -2,14 +2,15 @@ package com.teobaranga.monica.account
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.ShapeDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,43 +18,48 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.ramcosta.composedestinations.annotation.Destination
-import com.ramcosta.composedestinations.annotation.RootGraph
-import com.ramcosta.composedestinations.bottomsheet.spec.DestinationStyleBottomSheet
 import com.teobaranga.monica.ui.PreviewPixel4
 import com.teobaranga.monica.ui.theme.MonicaTheme
 
-@Destination<RootGraph>(style = DestinationStyleBottomSheet::class)
 @Composable
-fun ColumnScope.Account() {
+fun Account(
+    onDismissRequest: () -> Unit,
+) {
     val viewModel = hiltViewModel<AccountViewModel>()
     AccountScreen(
         onClearAuthorization = viewModel::onClearAuthorization,
+        onDismissRequest = onDismissRequest,
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ColumnScope.AccountScreen(
+private fun AccountScreen(
     onClearAuthorization: () -> Unit,
+    onDismissRequest: () -> Unit,
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .statusBarsPadding()
-            .padding(horizontal = 20.dp)
-            .clip(ShapeDefaults.Large)
-            .background(MaterialTheme.colorScheme.background),
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
     ) {
-        Button(
-            onClick = onClearAuthorization,
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .statusBarsPadding()
+                .padding(horizontal = 20.dp)
+                .clip(ShapeDefaults.Large)
+                .background(MaterialTheme.colorScheme.background),
         ) {
-            Text(text = "Sign out")
+            Button(
+                onClick = onClearAuthorization,
+            ) {
+                Text(text = "Sign out")
+            }
         }
+        Spacer(
+            modifier = Modifier
+                .weight(1f),
+        )
     }
-    Spacer(
-        modifier = Modifier
-            .weight(1f),
-    )
 }
 
 @PreviewPixel4
@@ -66,6 +72,7 @@ fun PreviewAccountScreen() {
         ) {
             AccountScreen(
                 onClearAuthorization = { },
+                onDismissRequest = { },
             )
         }
     }

--- a/app/src/main/java/com/teobaranga/monica/contacts/ContactsNavGraph.kt
+++ b/app/src/main/java/com/teobaranga/monica/contacts/ContactsNavGraph.kt
@@ -1,7 +1,6 @@
 import com.ramcosta.composedestinations.annotation.NavGraph
 
-@HomeNavGraph
-@NavGraph(route = "root_contacts")
+@NavGraph<HomeNavGraph>(route = "root_contacts")
 annotation class ContactsNavGraph(
     val start: Boolean = false
 )

--- a/app/src/main/java/com/teobaranga/monica/contacts/detail/ContactDetailScreen.kt
+++ b/app/src/main/java/com/teobaranga/monica/contacts/detail/ContactDetailScreen.kt
@@ -38,8 +38,7 @@ import com.teobaranga.monica.ui.avatar.UserAvatar
 import com.teobaranga.monica.ui.theme.MonicaTheme
 import com.teobaranga.monica.util.compose.nestedScrollParentFirst
 
-@ContactsNavGraph
-@Destination
+@Destination<ContactsNavGraph>
 @Composable
 fun ContactDetail(
     navigator: DestinationsNavigator,

--- a/app/src/main/java/com/teobaranga/monica/contacts/list/ContactsScreen.kt
+++ b/app/src/main/java/com/teobaranga/monica/contacts/list/ContactsScreen.kt
@@ -37,19 +37,18 @@ import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.ramcosta.composedestinations.annotation.Destination
+import com.ramcosta.composedestinations.generated.destinations.ContactDetailDestination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.teobaranga.monica.MonicaBackground
 import com.teobaranga.monica.contacts.list.model.Contact
 import com.teobaranga.monica.ui.MonicaSearchBar
-import com.teobaranga.monica.destinations.ContactDetailDestination
 import com.teobaranga.monica.ui.PreviewPixel4
 import com.teobaranga.monica.ui.avatar.UserAvatar
 import com.teobaranga.monica.ui.plus
 import com.teobaranga.monica.ui.theme.MonicaTheme
 import kotlinx.coroutines.flow.flowOf
 
-@ContactsNavGraph(start = true)
-@Destination
+@Destination<ContactsNavGraph>(start = true)
 @Composable
 fun Contacts(
     navigator: DestinationsNavigator,

--- a/app/src/main/java/com/teobaranga/monica/contacts/list/ContactsScreen.kt
+++ b/app/src/main/java/com/teobaranga/monica/contacts/list/ContactsScreen.kt
@@ -15,21 +15,20 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.pullrefresh.PullRefreshIndicator
-import androidx.compose.material.pullrefresh.pullRefresh
-import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
@@ -73,7 +72,7 @@ fun Contacts(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ContactsScreen(
     userAvatar: UserAvatar?,
@@ -102,28 +101,21 @@ private fun ContactsScreen(
             }
         },
     )
-    val pullRefreshState = rememberPullRefreshState(
-        refreshing = isRefreshing,
-        onRefresh = onRefresh,
-    )
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .statusBarsPadding()
-            .padding(top = SearchBarDefaults.InputFieldHeight + 20.dp)
-            .zIndex(2f)
-    ) {
-        PullRefreshIndicator(
-            modifier = Modifier
-                .align(Alignment.TopCenter),
-            refreshing = isRefreshing,
-            state = pullRefreshState,
-        )
+    val pullRefreshState = rememberPullToRefreshState()
+    if (pullRefreshState.isRefreshing) {
+        LaunchedEffect(Unit) {
+            onRefresh()
+        }
+    }
+    LaunchedEffect(isRefreshing) {
+        if (!isRefreshing) {
+            pullRefreshState.endRefresh()
+        }
     }
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .pullRefresh(pullRefreshState),
+            .nestedScroll(pullRefreshState.nestedScrollConnection),
     ) {
         LazyColumn(
             modifier = Modifier
@@ -160,6 +152,13 @@ private fun ContactsScreen(
                 }
             }
         }
+        PullToRefreshContainer(
+            modifier = Modifier
+                .statusBarsPadding()
+                .padding(top = SearchBarDefaults.InputFieldHeight)
+                .align(Alignment.TopCenter),
+            state = pullRefreshState,
+        )
     }
 }
 

--- a/app/src/main/java/com/teobaranga/monica/dashboard/DashboardNavGraph.kt
+++ b/app/src/main/java/com/teobaranga/monica/dashboard/DashboardNavGraph.kt
@@ -1,7 +1,6 @@
 import com.ramcosta.composedestinations.annotation.NavGraph
 
-@HomeNavGraph(start = true)
-@NavGraph(route = "root_dashboard")
+@NavGraph<HomeNavGraph>(start = true, route = "root_dashboard")
 annotation class DashboardNavGraph(
     val start: Boolean = false
 )

--- a/app/src/main/java/com/teobaranga/monica/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/teobaranga/monica/dashboard/DashboardScreen.kt
@@ -26,20 +26,19 @@ import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.ramcosta.composedestinations.annotation.Destination
+import com.ramcosta.composedestinations.generated.destinations.AccountDestination
+import com.ramcosta.composedestinations.generated.destinations.ContactDetailDestination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.teobaranga.monica.MonicaBackground
 import com.teobaranga.monica.contacts.list.model.Contact
 import com.teobaranga.monica.contacts.list.userAvatar
-import com.teobaranga.monica.destinations.AccountDestination
-import com.teobaranga.monica.destinations.ContactDetailDestination
 import com.teobaranga.monica.ui.MonicaSearchBar
 import com.teobaranga.monica.ui.PreviewPixel4
 import com.teobaranga.monica.ui.avatar.UserAvatar
 import com.teobaranga.monica.ui.theme.MonicaTheme
 import kotlinx.coroutines.flow.flowOf
 
-@DashboardNavGraph(start = true)
-@Destination
+@Destination<DashboardNavGraph>(start = true)
 @Composable
 fun Dashboard(
     navigator: DestinationsNavigator,

--- a/app/src/main/java/com/teobaranga/monica/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/teobaranga/monica/dashboard/DashboardScreen.kt
@@ -16,6 +16,9 @@ import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -26,10 +29,10 @@ import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.ramcosta.composedestinations.annotation.Destination
-import com.ramcosta.composedestinations.generated.destinations.AccountDestination
 import com.ramcosta.composedestinations.generated.destinations.ContactDetailDestination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.teobaranga.monica.MonicaBackground
+import com.teobaranga.monica.account.Account
 import com.teobaranga.monica.contacts.list.model.Contact
 import com.teobaranga.monica.contacts.list.userAvatar
 import com.teobaranga.monica.ui.MonicaSearchBar
@@ -46,16 +49,24 @@ fun Dashboard(
     val viewModel = hiltViewModel<DashboardViewModel>()
     val userUiState by viewModel.userUiState.collectAsStateWithLifecycle()
     val recentContacts = viewModel.recentContacts.collectAsLazyPagingItems()
+    var shouldShowAccount by remember { mutableStateOf(false) }
     DashboardScreen(
         userUiState = userUiState,
         recentContacts = recentContacts,
         onAvatarClick = {
-            viewModel.navigateTo(AccountDestination)
+            shouldShowAccount = true
         },
         onContactSelected = { contactId ->
             navigator.navigate(ContactDetailDestination(contactId))
         }
     )
+    if (shouldShowAccount) {
+        Account(
+            onDismissRequest = {
+                shouldShowAccount = false
+            },
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/com/teobaranga/monica/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/teobaranga/monica/dashboard/DashboardViewModel.kt
@@ -5,12 +5,12 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.cachedIn
+import com.ramcosta.composedestinations.spec.DirectionDestinationSpec
 import com.teobaranga.monica.contacts.data.ContactRepository
 import com.teobaranga.monica.contacts.data.ContactSynchronizer
 import com.teobaranga.monica.contacts.list.userAvatar
 import com.teobaranga.monica.data.photo.PhotoSynchronizer
 import com.teobaranga.monica.data.user.UserRepository
-import com.teobaranga.monica.destinations.DirectionDestination
 import com.teobaranga.monica.home.HomeNavigationManager
 import com.teobaranga.monica.user.userAvatar
 import com.teobaranga.monica.util.coroutines.Dispatcher
@@ -67,7 +67,7 @@ internal class DashboardViewModel @Inject constructor(
         .flow
         .cachedIn(viewModelScope)
 
-    fun navigateTo(destination: DirectionDestination) {
+    fun navigateTo(destination: DirectionDestinationSpec) {
         homeNavigationManager.navigateTo(destination)
     }
 

--- a/app/src/main/java/com/teobaranga/monica/home/HomeNavGraph.kt
+++ b/app/src/main/java/com/teobaranga/monica/home/HomeNavGraph.kt
@@ -1,6 +1,6 @@
-import com.ramcosta.composedestinations.annotation.NavGraph
+import com.ramcosta.composedestinations.annotation.NavHostGraph
 
-@NavGraph(route = "root_home")
+@NavHostGraph(route = "root_home")
 annotation class HomeNavGraph(
     val start: Boolean = false,
 )

--- a/app/src/main/java/com/teobaranga/monica/home/HomeNavigationBar.kt
+++ b/app/src/main/java/com/teobaranga/monica/home/HomeNavigationBar.kt
@@ -9,26 +9,25 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.navigation.NavController
-import com.ramcosta.composedestinations.navigation.navigate
-import com.teobaranga.monica.NavGraphs
-import com.teobaranga.monica.appCurrentDestinationAsState
-import com.teobaranga.monica.destinations.Destination
-import com.teobaranga.monica.startAppDestination
+import com.ramcosta.composedestinations.generated.NavGraphs
+import com.ramcosta.composedestinations.spec.DestinationSpec
+import com.ramcosta.composedestinations.utils.currentDestinationAsState
+import com.ramcosta.composedestinations.utils.startDestination
 
 @Composable
 fun HomeNavigationBar(
     modifier: Modifier = Modifier,
     navController: NavController,
 ) {
-    val currentDestination: Destination? by navController.appCurrentDestinationAsState()
+    val currentDestination: DestinationSpec? by navController.currentDestinationAsState()
     NavigationBar(
         modifier = modifier,
     ) {
         for (homeTab in HomeTab.entries) {
             NavigationBarItem(
-                selected = homeTab.destination.destinations.contains(currentDestination?.startAppDestination),
+                selected = homeTab.destination.destinations.contains(currentDestination?.startDestination),
                 onClick = {
-                    navController.navigate(homeTab.destination) {
+                    navController.navigate(homeTab.destination.route) {
                         launchSingleTop = true
                         restoreState = true
                         // make the dashboard screen the last one before exiting

--- a/app/src/main/java/com/teobaranga/monica/home/HomeNavigationManager.kt
+++ b/app/src/main/java/com/teobaranga/monica/home/HomeNavigationManager.kt
@@ -1,6 +1,6 @@
 package com.teobaranga.monica.home
 
-import com.teobaranga.monica.destinations.DirectionDestination
+import com.ramcosta.composedestinations.spec.DirectionDestinationSpec
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import javax.inject.Inject
@@ -9,10 +9,10 @@ import javax.inject.Singleton
 @Singleton
 class HomeNavigationManager @Inject constructor() {
 
-    private val _navigation = MutableSharedFlow<DirectionDestination>(extraBufferCapacity = 1)
+    private val _navigation = MutableSharedFlow<DirectionDestinationSpec>(extraBufferCapacity = 1)
     val navigation = _navigation.asSharedFlow()
 
-    fun navigateTo(destination: DirectionDestination) {
+    fun navigateTo(destination: DirectionDestinationSpec) {
         _navigation.tryEmit(destination)
     }
 }

--- a/app/src/main/java/com/teobaranga/monica/home/HomeScreen.kt
+++ b/app/src/main/java/com/teobaranga/monica/home/HomeScreen.kt
@@ -16,19 +16,18 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ramcosta.composedestinations.DestinationsNavHost
 import com.ramcosta.composedestinations.annotation.Destination
-import com.ramcosta.composedestinations.annotation.RootNavGraph
+import com.ramcosta.composedestinations.annotation.RootGraph
+import com.ramcosta.composedestinations.generated.NavGraphs
+import com.ramcosta.composedestinations.generated.destinations.HomeDestination
+import com.ramcosta.composedestinations.generated.destinations.SetupDestination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.ramcosta.composedestinations.rememberNavHostEngine
 import com.teobaranga.monica.MonicaBackground
-import com.teobaranga.monica.NavGraphs
-import com.teobaranga.monica.destinations.HomeDestination
-import com.teobaranga.monica.destinations.SetupDestination
 import com.teobaranga.monica.ui.PreviewPixel4
 import com.teobaranga.monica.ui.theme.MonicaTheme
 import kotlinx.coroutines.flow.collectLatest
 
-@RootNavGraph(start = true)
-@Destination
+@Destination<RootGraph>(start = true)
 @Composable
 fun Home(
     navigator: DestinationsNavigator,

--- a/app/src/main/java/com/teobaranga/monica/home/HomeTab.kt
+++ b/app/src/main/java/com/teobaranga/monica/home/HomeTab.kt
@@ -5,13 +5,13 @@ import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.filled.Dashboard
 import androidx.compose.material.icons.filled.Groups
 import androidx.compose.ui.graphics.vector.ImageVector
-import com.teobaranga.monica.NavGraph
-import com.teobaranga.monica.NavGraphs
+import com.ramcosta.composedestinations.generated.NavGraphs
+import com.ramcosta.composedestinations.spec.NavGraphSpec
 
 enum class HomeTab(
     val icon: ImageVector,
     val label: String,
-    val destination: NavGraph,
+    val destination: NavGraphSpec,
 ) {
     DASHBOARD(
         icon = Icons.Default.Dashboard,

--- a/app/src/main/java/com/teobaranga/monica/journal/JournalNavGraph.kt
+++ b/app/src/main/java/com/teobaranga/monica/journal/JournalNavGraph.kt
@@ -1,7 +1,6 @@
 import com.ramcosta.composedestinations.annotation.NavGraph
 
-@HomeNavGraph
-@NavGraph(route = "root_journal")
+@NavGraph<HomeNavGraph>(route = "root_journal")
 annotation class JournalNavGraph(
     val start: Boolean = false
 )

--- a/app/src/main/java/com/teobaranga/monica/journal/list/JournalEntryList.kt
+++ b/app/src/main/java/com/teobaranga/monica/journal/list/JournalEntryList.kt
@@ -7,12 +7,11 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.ramcosta.composedestinations.annotation.Destination
+import com.ramcosta.composedestinations.generated.destinations.JournalEntryDestination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
-import com.teobaranga.monica.destinations.JournalEntryDestination
 import com.teobaranga.monica.journal.list.ui.JournalEntryListScreen
 
-@JournalNavGraph(start = true)
-@Destination
+@Destination<JournalNavGraph>(start = true)
 @Composable
 fun JournalEntryList(
     navigator: DestinationsNavigator,

--- a/app/src/main/java/com/teobaranga/monica/journal/list/ui/JournalEntryListScreen.kt
+++ b/app/src/main/java/com/teobaranga/monica/journal/list/ui/JournalEntryListScreen.kt
@@ -7,28 +7,26 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.pullrefresh.PullRefreshIndicator
-import androidx.compose.material.pullrefresh.pullRefresh
-import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SearchBarDefaults
+import androidx.compose.material3.pulltorefresh.PullToRefreshContainer
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.zIndex
 import androidx.paging.LoadState
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
@@ -45,7 +43,7 @@ import java.time.ZonedDateTime
 private val fabHeight = 56.dp
 private val fabPadding = 20.dp
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun JournalEntryListScreen(
     userAvatar: UserAvatar?,
@@ -75,28 +73,21 @@ fun JournalEntryListScreen(
             }
         },
     )
-    val pullRefreshState = rememberPullRefreshState(
-        refreshing = isRefreshing,
-        onRefresh = onRefresh,
-    )
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .statusBarsPadding()
-            .padding(top = SearchBarDefaults.InputFieldHeight + 20.dp)
-            .zIndex(2f)
-    ) {
-        PullRefreshIndicator(
-            modifier = Modifier
-                .align(Alignment.TopCenter),
-            refreshing = isRefreshing,
-            state = pullRefreshState,
-        )
+    val pullRefreshState = rememberPullToRefreshState()
+    if (pullRefreshState.isRefreshing) {
+        LaunchedEffect(Unit) {
+            onRefresh()
+        }
+    }
+    LaunchedEffect(isRefreshing) {
+        if (!isRefreshing) {
+            pullRefreshState.endRefresh()
+        }
     }
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .pullRefresh(pullRefreshState),
+            .nestedScroll(pullRefreshState.nestedScrollConnection),
     ) {
         LazyColumn(
             modifier = Modifier
@@ -138,6 +129,13 @@ fun JournalEntryListScreen(
                 }
             }
         }
+        PullToRefreshContainer(
+            modifier = Modifier
+                .statusBarsPadding()
+                .padding(top = SearchBarDefaults.InputFieldHeight)
+                .align(Alignment.TopCenter),
+            state = pullRefreshState,
+        )
         FloatingActionButton(
             modifier = Modifier
                 .align(Alignment.BottomEnd)

--- a/app/src/main/java/com/teobaranga/monica/journal/view/JournalEntry.kt
+++ b/app/src/main/java/com/teobaranga/monica/journal/view/JournalEntry.kt
@@ -16,8 +16,7 @@ import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.spec.DestinationStyle
 import com.teobaranga.monica.journal.view.ui.JournalEntryScreen
 
-@JournalNavGraph
-@Destination(
+@Destination<JournalNavGraph>(
     style = JournalEntryTransitions::class,
 )
 @Composable
@@ -35,13 +34,13 @@ fun JournalEntry(
     )
 }
 
-object JournalEntryTransitions : DestinationStyle.Animated {
+object JournalEntryTransitions : DestinationStyle.Animated() {
 
-    override fun AnimatedContentTransitionScope<NavBackStackEntry>.enterTransition(): EnterTransition {
-        return fadeIn(animationSpec = tween(300))
+    override val enterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition?) = {
+        fadeIn(animationSpec = tween(300))
     }
 
-    override fun AnimatedContentTransitionScope<NavBackStackEntry>.exitTransition(): ExitTransition {
-        return fadeOut(animationSpec = tween(300))
+    override val exitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition?) = {
+        fadeOut(animationSpec = tween(300))
     }
 }

--- a/app/src/main/java/com/teobaranga/monica/setup/SetupScreen.kt
+++ b/app/src/main/java/com/teobaranga/monica/setup/SetupScreen.kt
@@ -32,18 +32,19 @@ import androidx.core.util.Consumer
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ramcosta.composedestinations.annotation.Destination
+import com.ramcosta.composedestinations.annotation.RootGraph
+import com.ramcosta.composedestinations.generated.NavGraphs
+import com.ramcosta.composedestinations.generated.destinations.SetupDestination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import com.teobaranga.monica.MonicaBackground
-import com.teobaranga.monica.NavGraphs
 import com.teobaranga.monica.R
 import com.teobaranga.monica.data.PARAM_CODE
-import com.teobaranga.monica.destinations.SetupDestination
 import com.teobaranga.monica.ui.PreviewPixel4
 import com.teobaranga.monica.ui.theme.MonicaTheme
 import com.teobaranga.monica.util.compose.keyboardAsState
 import kotlinx.coroutines.flow.collectLatest
 
-@Destination
+@Destination<RootGraph>
 @Composable
 fun Setup(
     navigator: DestinationsNavigator,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,7 +67,6 @@ ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-material = { group = "androidx.compose.material", name = "material" }
 material3 = { group = "androidx.compose.material3", name = "material3" }
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,6 @@ androidx-compose-material-icons = { group = "androidx.compose.material", name = 
 browser = { group = "androidx.browser", name = "browser", version.ref = "browser" }
 coil = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 compose-destinations-core = { group = "io.github.raamcosta.compose-destinations", name = "core", version.ref = "compose-destinations" }
-compose-destinations-bottom-sheet = { group = "io.github.raamcosta.compose-destinations", name = "bottom-sheet", version.ref = "compose-destinations" }
 compose-destinations-ksp = { group = "io.github.raamcosta.compose-destinations", name = "ksp", version.ref = "compose-destinations" }
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ kotlin = "1.9.23"
 ksp = "1.9.23-1.0.20"
 browser = "1.8.0"
 coil = "2.6.0"
-compose-destinations = "1.10.2"
+compose-destinations = "2.1.0-beta01"
 core-ktx = "1.13.0"
 datastore = "1.1.0"
 desugar-jdk-libs = "2.0.4"
@@ -30,7 +30,8 @@ compose-bom = "2024.04.01"
 androidx-compose-material-icons = { group = "androidx.compose.material", name = "material-icons-extended" }
 browser = { group = "androidx.browser", name = "browser", version.ref = "browser" }
 coil = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
-compose-destinations-core = { group = "io.github.raamcosta.compose-destinations", name = "animations-core", version.ref = "compose-destinations" }
+compose-destinations-core = { group = "io.github.raamcosta.compose-destinations", name = "core", version.ref = "compose-destinations" }
+compose-destinations-bottom-sheet = { group = "io.github.raamcosta.compose-destinations", name = "bottom-sheet", version.ref = "compose-destinations" }
 compose-destinations-ksp = { group = "io.github.raamcosta.compose-destinations", name = "ksp", version.ref = "compose-destinations" }
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }


### PR DESCRIPTION
- Updated compose-destinations to 2.1.0-beta01 to reduce complexity around navigation (no more nav engine or bottom sheet navigator)
- Migrated the Account screen to a Material3 bottom sheet which doesn't need to be a navigation destination anymore
- Migrated to the Material 3 pull to refresh

The last two allow dropping the material 2 dependency.