### PR TITLE
permit cleartext traffic on arbitrary `localdomain`

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <!--
+        Permit cleartext connections to the local network through "localdomain", which
+        is useful for self-hosted Monica instances.
+        There is no particular convention around this domain name, it could also be
+        .local, .home, or anything similar.
+         -->
+        <domain includeSubdomains="true">localdomain</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
If trying to connect to a self-hosted instance of Monica, it must be put behind a reverse proxy with SSL, which can take some time to set up and may not be desired if the server isn't meant to be exposed to the Internet.

For a simpler connection, these changes allow creatext connections for anything matching `*.localdomain`. This allows connecting to URLs like `http://monica.localdomain` or `http://localdomain:8080` where Monica is hosted. A custom DNS entry would then be needed.