### PR TITLE
fix: database getting cleared on api errors

### DIFF
--- a/app/src/main/java/com/teobaranga/monica/contacts/data/ContactSynchronizer.kt
+++ b/app/src/main/java/com/teobaranga/monica/contacts/data/ContactSynchronizer.kt
@@ -1,6 +1,6 @@
 package com.teobaranga.monica.contacts.data
 
-import com.skydoves.sandwich.getOrNull
+import com.skydoves.sandwich.getOrElse
 import com.skydoves.sandwich.onFailure
 import com.teobaranga.monica.data.sync.Synchronizer
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -29,7 +29,10 @@ class ContactSynchronizer @Inject constructor(
                 .onFailure {
                     Timber.w("Error while loading contacts: %s", this)
                 }
-                .getOrNull() ?: break
+                .getOrElse {
+                    syncState.value = Synchronizer.State.IDLE
+                    return
+                }
             val contactEntities = contactsResponse.data
                 .map {
                     it.toEntity()

--- a/app/src/main/java/com/teobaranga/monica/data/photo/PhotoSynchronizer.kt
+++ b/app/src/main/java/com/teobaranga/monica/data/photo/PhotoSynchronizer.kt
@@ -1,6 +1,6 @@
 package com.teobaranga.monica.data.photo
 
-import com.skydoves.sandwich.getOrNull
+import com.skydoves.sandwich.getOrElse
 import com.skydoves.sandwich.onFailure
 import com.teobaranga.monica.contacts.data.ContactPhotosResponse
 import com.teobaranga.monica.data.sync.Synchronizer
@@ -30,7 +30,10 @@ class PhotoSynchronizer @Inject constructor(
                 .onFailure {
                     Timber.w("Error while loading photos: %s", this)
                 }
-                .getOrNull() ?: break
+                .getOrElse {
+                    syncState.value = Synchronizer.State.IDLE
+                    return
+                }
             val photoEntities = photosResponse.data
                 .map {
                     it.toEntity()

--- a/app/src/main/java/com/teobaranga/monica/journal/data/JournalSynchronizer.kt
+++ b/app/src/main/java/com/teobaranga/monica/journal/data/JournalSynchronizer.kt
@@ -1,6 +1,6 @@
 package com.teobaranga.monica.journal.data
 
-import com.skydoves.sandwich.getOrNull
+import com.skydoves.sandwich.getOrElse
 import com.skydoves.sandwich.onFailure
 import com.teobaranga.monica.data.sync.Synchronizer
 import com.teobaranga.monica.journal.database.JournalDao
@@ -31,7 +31,10 @@ class JournalSynchronizer @Inject constructor(
                 .onFailure {
                     Timber.w("Error while loading journal: %s", this)
                 }
-                .getOrNull() ?: break
+                .getOrElse {
+                    syncState.value = Synchronizer.State.IDLE
+                    return
+                }
             val journalEntries = journalEntriesResponse.data
                 .map {
                     it.toEntity()


### PR DESCRIPTION
The synchronizers keep track of the removed items by starting with the list of all items and removing the fetched ones. If the fetching failed, the full list of items was removed incorrectly. These changes make the synchronizers return immediately on failure, avoiding any unintended deletion.