### PR TITLE
feat(setup): improve user presence logic

### DIFF
--- a/app/src/main/java/com/teobaranga/monica/auth/AuthorizationRepository.kt
+++ b/app/src/main/java/com/teobaranga/monica/auth/AuthorizationRepository.kt
@@ -2,39 +2,31 @@ package com.teobaranga.monica.auth
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.edit
-import com.skydoves.sandwich.getOrNull
-import com.skydoves.sandwich.onFailure
-import com.teobaranga.monica.data.MonicaApi
-import com.teobaranga.monica.data.TokenRequest
+import com.teobaranga.monica.data.user.UserDao
 import com.teobaranga.monica.settings.getTokenStorage
-import com.teobaranga.monica.settings.tokenStorage
 import com.teobaranga.monica.util.coroutines.Dispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import timber.log.Timber
 import javax.inject.Inject
-import javax.inject.Provider
 import javax.inject.Singleton
 
 interface AuthorizationRepository {
 
     val isLoggedIn: StateFlow<Boolean?>
-
-    suspend fun signIn(clientId: String, clientSecret: String, authorizationCode: String): Boolean
 }
 
 @Singleton
 class MonicaAuthorizationRepository @Inject constructor(
     private val dispatcher: Dispatcher,
     private val dataStore: DataStore<Preferences>,
-    private val monicaApi: Provider<MonicaApi>,
+    private val userDao: UserDao,
 ) : AuthorizationRepository {
     private val scope = CoroutineScope(SupervisorJob() + dispatcher.io)
 
@@ -43,29 +35,20 @@ class MonicaAuthorizationRepository @Inject constructor(
 
     init {
         scope.launch {
-            dataStore.data
-                .collectLatest { preferences ->
-                    val tokenStorage = preferences.getTokenStorage()
-                    withContext(dispatcher.main) {
-                        _isLoggedIn.emit(tokenStorage.authorizationCode != null)
+            combine(
+                dataStore.data,
+                userDao.getMe(),
+            ) { preferences, me ->
+                val tokenStorage = preferences.getTokenStorage()
+                withContext(dispatcher.main) {
+                    val isLoggedIn = when {
+                        tokenStorage.authorizationCode == null -> false
+                        me == null -> false
+                        else -> true
                     }
+                    _isLoggedIn.emit(isLoggedIn)
                 }
+            }.collect()
         }
-    }
-
-    override suspend fun signIn(clientId: String, clientSecret: String, authorizationCode: String): Boolean {
-        val tokenResponse = monicaApi.get().getAccessToken(TokenRequest(clientId, clientSecret, authorizationCode))
-            .onFailure {
-                Timber.w("Failed to get access token: %s", this)
-            }
-            .getOrNull() ?: return false
-        dataStore.edit { preferences ->
-            preferences.tokenStorage {
-                setAuthorizationCode(authorizationCode)
-                setAccessToken(tokenResponse.accessToken)
-                setRefreshToken(tokenResponse.refreshToken)
-            }
-        }
-        return true
     }
 }

--- a/app/src/main/java/com/teobaranga/monica/setup/UiState.kt
+++ b/app/src/main/java/com/teobaranga/monica/setup/UiState.kt
@@ -1,5 +1,6 @@
 package com.teobaranga.monica.setup
 
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -7,6 +8,7 @@ import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.input.TextFieldValue
 
+@Stable
 class UiState {
 
     sealed interface Error {
@@ -22,8 +24,13 @@ class UiState {
     var clientSecret by mutableStateOf(TextFieldValue())
         private set
 
+    var isSigningIn by mutableStateOf(false)
+
     val isSignInEnabled by derivedStateOf {
-        serverAddress.text.isNotBlank() && clientId.text.isNotBlank() && clientSecret.text.isNotBlank()
+        serverAddress.text.isNotBlank() &&
+            clientId.text.isNotBlank() &&
+            clientSecret.text.isNotBlank() &&
+            !isSigningIn
     }
 
     var error: Error? by mutableStateOf(null)

--- a/app/src/main/java/com/teobaranga/monica/setup/domain/SignInUseCase.kt
+++ b/app/src/main/java/com/teobaranga/monica/setup/domain/SignInUseCase.kt
@@ -1,0 +1,54 @@
+package com.teobaranga.monica.setup.domain
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import com.skydoves.sandwich.getOrNull
+import com.skydoves.sandwich.onFailure
+import com.teobaranga.monica.data.MonicaApi
+import com.teobaranga.monica.data.TokenRequest
+import com.teobaranga.monica.data.user.UserRepository
+import com.teobaranga.monica.settings.tokenStorage
+import com.teobaranga.monica.util.coroutines.Dispatcher
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Provider
+
+class SignInUseCase @Inject internal constructor(
+    private val dispatcher: Dispatcher,
+    private val monicaApi: Provider<MonicaApi>,
+    private val dataStore: DataStore<Preferences>,
+    private val userRepository: UserRepository,
+) {
+
+    suspend operator fun invoke(clientId: String, clientSecret: String, authorizationCode: String): Boolean {
+        return withContext(dispatcher.io) {
+            // Fetch the access token
+            val tokenResponse = monicaApi.get().getAccessToken(TokenRequest(clientId, clientSecret, authorizationCode))
+                .onFailure {
+                    Timber.w("Failed to get access token: %s", this)
+                }
+                .getOrNull() ?: return@withContext false
+
+            // Store the token
+            dataStore.edit { preferences ->
+                preferences.tokenStorage {
+                    setAuthorizationCode(authorizationCode)
+                    setAccessToken(tokenResponse.accessToken)
+                    setRefreshToken(tokenResponse.refreshToken)
+                }
+            }
+
+            // Store the current user, marking the sign in as complete
+            try {
+                userRepository.sync()
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to sync user")
+                return@withContext false
+            }
+
+            true
+        }
+    }
+}


### PR DESCRIPTION
Given the previous work to clear the database on a fresh app launch, it was possible to have an empty database but be marked as "signed in", which led to an empty dashboard screen. The logged in logic now takes into account whether a `me` entity is present in the database, which truly marks a logged in user.