### PR TITLE
fix(activities): fix one-to-many relationship

### DIFF
--- a/app/src/main/java/com/teobaranga/monica/activities/data/ContactActivitiesDao.kt
+++ b/app/src/main/java/com/teobaranga/monica/activities/data/ContactActivitiesDao.kt
@@ -24,28 +24,11 @@ abstract class ContactActivitiesDao {
     @Transaction
     abstract fun getContactActivities(contactId: Int): Flow<List<ContactActivityWithParticipants>>
 
-    @Query(
-        """
-        SELECT contact_activity.* FROM contact_activity
-        INNER JOIN contact_activity_cross_refs ON contact_activity_cross_refs.activityId = contact_activity.activityId
-        INNER JOIN contacts ON contacts.contactId = contact_activity_cross_refs.contactId
-        WHERE contact_activity.activityId = :activityId
-        """,
-    )
-    @RewriteQueriesToDropUnusedColumns
+    @Query("SELECT * FROM contact_activity WHERE activityId = :activityId")
     @Transaction
     abstract fun getActivity(activityId: Int): Flow<ContactActivityWithParticipants>
 
-    @Query(
-        """
-        SELECT contact_activity.* FROM contact_activity
-        INNER JOIN contact_activity_cross_refs ON contact_activity_cross_refs.activityId = contact_activity.activityId
-        INNER JOIN contacts ON contacts.contactId = contact_activity_cross_refs.contactId
-        WHERE contact_activity.syncStatus = :status
-        ORDER BY date(date) DESC
-        """,
-    )
-    @RewriteQueriesToDropUnusedColumns
+    @Query("SELECT * FROM contact_activity WHERE syncStatus = :status ORDER BY date(date) DESC")
     @Transaction
     abstract suspend fun getActivitiesByStatus(status: SyncStatus): List<ContactActivityWithParticipants>
 

--- a/app/src/main/java/com/teobaranga/monica/activities/data/ContactActivitiesRepository.kt
+++ b/app/src/main/java/com/teobaranga/monica/activities/data/ContactActivitiesRepository.kt
@@ -50,10 +50,10 @@ internal class ContactActivitiesRepository @Inject constructor(
          * Create new entry using API
          * Insert response into Room, should ideally have a similar ID but keep a map of local to remote ID
          */
-        val localId = contactActivitiesDao.getMaxId() + 1
+        val activityId = contactActivitiesDao.getMaxId() + 1
         val createdDate = OffsetDateTime.now()
         val entity = ContactActivityEntity(
-            activityId = localId,
+            activityId = activityId,
             title = title,
             description = description,
             date = date,
@@ -62,10 +62,10 @@ internal class ContactActivitiesRepository @Inject constructor(
             syncStatus = SyncStatus.NEW,
         )
         val crossRefs = participants
-            .map {
+            .map { contactId ->
                 ContactActivityCrossRef(
-                    contactId = it,
-                    activityId = localId,
+                    contactId = contactId,
+                    activityId = activityId,
                 )
             }
         contactActivitiesDao.upsert(


### PR DESCRIPTION
The previous query actually returned the same activity multiplied by the amount of participants. The complexity wasn't needed because the expected behaviour is just achieved with the `ContactActivityWithParticipants` class.