### PR TITLE
feat(app): sync using WorkManager

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,6 +100,9 @@ dependencies {
 
     implementation(platform(libs.firebase.bom))
 
+    implementation(libs.work)
+    implementation(libs.hilt.work)
+
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,6 +43,19 @@
                 android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />
         </activity>
+
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <!-- The WorkManager initialisation is overridden in the App class -->
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/teobaranga/monica/MonicaApp.kt
+++ b/app/src/main/java/com/teobaranga/monica/MonicaApp.kt
@@ -1,15 +1,19 @@
 package com.teobaranga.monica
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
+import androidx.work.WorkManager
 import coil.ImageLoader
 import coil.ImageLoaderFactory
+import com.teobaranga.monica.sync.SyncWorker
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Provider
 
 @HiltAndroidApp
-class MonicaApp : Application(), ImageLoaderFactory {
+class MonicaApp : Application(), ImageLoaderFactory, Configuration.Provider {
 
     @Inject
     lateinit var timberTrees: Set<@JvmSuppressWildcards Timber.Tree>
@@ -17,13 +21,26 @@ class MonicaApp : Application(), ImageLoaderFactory {
     @Inject
     lateinit var imageLoader: Provider<ImageLoader>
 
+    @Inject
+    lateinit var workerFactory: HiltWorkerFactory
+
+    @Inject
+    lateinit var workManager: WorkManager
+
     override fun onCreate() {
         super.onCreate()
 
         Timber.plant(*timberTrees.toTypedArray())
+
+        SyncWorker.enqueue(workManager)
     }
 
     override fun newImageLoader(): ImageLoader {
         return imageLoader.get()
     }
+
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
 }

--- a/app/src/main/java/com/teobaranga/monica/di/WorkModule.kt
+++ b/app/src/main/java/com/teobaranga/monica/di/WorkModule.kt
@@ -1,0 +1,23 @@
+package com.teobaranga.monica.di
+
+import android.content.Context
+import androidx.work.WorkManager
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+interface WorkModule {
+
+    companion object {
+
+        @[Provides Singleton]
+        fun provideWorkManager(@ApplicationContext context: Context): WorkManager {
+            return WorkManager.getInstance(context)
+        }
+    }
+}

--- a/app/src/main/java/com/teobaranga/monica/home/HomeViewModel.kt
+++ b/app/src/main/java/com/teobaranga/monica/home/HomeViewModel.kt
@@ -1,30 +1,17 @@
 package com.teobaranga.monica.home
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.teobaranga.monica.auth.AuthorizationRepository
-import com.teobaranga.monica.core.dispatcher.Dispatcher
-import com.teobaranga.monica.genders.data.GenderRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 internal class HomeViewModel @Inject constructor(
-    dispatcher: Dispatcher,
     authorizationRepository: AuthorizationRepository,
     homeNavigationManager: HomeNavigationManager,
-    private val genderRepository: GenderRepository,
 ) : ViewModel() {
 
     val isLoggedIn = authorizationRepository.isLoggedIn
 
     val navigation = homeNavigationManager.navigation
-
-    init {
-        // TODO: may not be the best place to load data
-        viewModelScope.launch(dispatcher.io) {
-            genderRepository.fetchLatestGenders()
-        }
-    }
 }

--- a/app/src/main/java/com/teobaranga/monica/sync/SyncWorker.kt
+++ b/app/src/main/java/com/teobaranga/monica/sync/SyncWorker.kt
@@ -1,0 +1,78 @@
+package com.teobaranga.monica.sync
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.hilt.work.HiltWorker
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequest
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.OutOfQuotaPolicy
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.teobaranga.monica.data.user.UserRepository
+import com.teobaranga.monica.genders.data.GenderRepository
+import com.teobaranga.monica.settings.getTokenStorage
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.flow.first
+import timber.log.Timber
+
+@HiltWorker
+internal class SyncWorker @AssistedInject constructor(
+    @Assisted
+    appContext: Context,
+    @Assisted
+    workerParams: WorkerParameters,
+    private val dataStore: DataStore<Preferences>,
+    private val userRepository: UserRepository,
+    private val genderRepository: GenderRepository,
+) : CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
+        val isTokenAvailable = dataStore.data.first().getTokenStorage().accessToken != null
+        if (!isTokenAvailable) {
+            Timber.d("Access token not available, skipping sync")
+            return Result.success()
+        }
+
+        Timber.d("Syncing current user")
+        userRepository.sync()
+
+        Timber.d("Syncing genders")
+        // TODO is this the best place? probably not
+        genderRepository.fetchLatestGenders()
+
+        return Result.success()
+    }
+
+    companion object {
+
+        // This name should not be changed otherwise the app may have concurrent sync requests running
+        private const val SYNC_WORK_NAME = "SyncWorkName"
+
+        private val SyncConstraints
+            get() = Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build()
+
+        fun enqueue(workManager: WorkManager) {
+            workManager
+                .enqueueUniqueWork(
+                    SYNC_WORK_NAME,
+                    ExistingWorkPolicy.KEEP,
+                    startUpSyncWork(),
+                )
+        }
+
+        private fun startUpSyncWork(): OneTimeWorkRequest {
+            return OneTimeWorkRequestBuilder<SyncWorker>()
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                .setConstraints(SyncConstraints)
+                .build()
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/HiltConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/HiltConventionPlugin.kt
@@ -36,6 +36,7 @@ class HiltConventionPlugin : Plugin<Project> {
                 pluginManager.apply(libs.plugins.hilt.get().pluginId)
                 dependencies {
                     implementation(libs.hilt.android)
+                    ksp(libs.hilt.compiler.androidx)
                 }
             }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ compileSdk = "35"
 androidGradlePlugin = "8.6.1"
 androidTools = "31.6.1"
 hilt = "2.52"
+hilt-androidx = "1.2.0"
 kotlin = "2.0.20"
 ksp = "2.0.20-1.0.25"
 ktlint = "12.1.1"
@@ -22,6 +23,7 @@ desugar-jdk-libs = "2.1.2"
 firebase-bom = "33.3.0"
 google-services = "4.4.2"
 hilt-navigation-compose = "1.2.0"
+hilt-work = "1.2.0"
 junit = "4.13.2"
 kotlinx-coroutines = "1.9.0"
 moshi = "1.15.1"
@@ -37,6 +39,7 @@ androidx-test-ext-junit = "1.2.1"
 espresso-core = "3.6.1"
 lifecycle = "2.8.6"
 activity-compose = "1.9.2"
+work = "2.9.1"
 
 [libraries]
 # Dependencies of the included build-logic
@@ -57,8 +60,10 @@ desugar-jdk-libs = { group = "com.android.tools", name = "desugar_jdk_libs", ver
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
+hilt-compiler-androidx = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hilt-androidx" }
 hilt-core = { group = "com.google.dagger", name = "hilt-core", version.ref = "hilt" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hilt-navigation-compose" }
+hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hilt-work" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
@@ -90,6 +95,7 @@ compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-mani
 compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 compose-rules-ktlint = { group = "io.nlopez.compose.rules", name = "ktlint", version.ref = "compose-rules-ktlint"  }
+work = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work"  }
 
 [plugins]
 # Plugins defined by this project


### PR DESCRIPTION
There was a crash on a fresh install caused by the gender repository attempting to refresh without there being an access token. This made it clear that that refresh strategy didn't work.

Instead, this commit moves the solution closer to what's in NowInAndroid and creates a SyncWorker that is mainly responsible for refreshing the critical data either once at app startup or after logging in.

Currently, the gender repository is considered "critical data" but this will change into a different strategy, perhaps marking repositories as stale instead...