### PR TITLE
fix(activity): fix contact dropdown flickering when searching

### DIFF
--- a/app/src/main/java/com/teobaranga/monica/contacts/data/ContactDao.kt
+++ b/app/src/main/java/com/teobaranga/monica/contacts/data/ContactDao.kt
@@ -51,8 +51,8 @@ abstract class ContactDao {
     )
     abstract fun getContact(id: Int): Flow<ContactEntity>
 
-    @Query("SELECT * FROM contacts WHERE completeName LIKE '%' || :query || '%'")
-    abstract suspend fun searchContacts(query: String): List<ContactEntity>
+    @Query("SELECT * FROM contacts WHERE completeName LIKE '%' || :query || '%' AND contactId NOT IN (:excludeIds)")
+    abstract suspend fun searchContacts(query: String, excludeIds: List<Int> = emptyList()): List<ContactEntity>
 
     @Transaction
     @Query("SELECT contactId, avatar_url FROM contacts WHERE contactId = :contactId")

--- a/app/src/main/java/com/teobaranga/monica/contacts/data/ContactRepository.kt
+++ b/app/src/main/java/com/teobaranga/monica/contacts/data/ContactRepository.kt
@@ -47,8 +47,8 @@ internal class ContactRepository @Inject constructor(
         return pagingSource.get().create(orderBy)
     }
 
-    suspend fun searchContact(query: String): List<ContactEntity> {
-        return contactDao.searchContacts(query)
+    suspend fun searchContact(query: String, excludeIds: List<Int> = emptyList()): List<ContactEntity> {
+        return contactDao.searchContacts(query, excludeIds)
     }
 
     fun getContacts(ids: List<Int>): Flow<List<ContactEntity>> {

--- a/app/src/main/java/com/teobaranga/monica/contacts/detail/activities/edit/domain/Activity.kt
+++ b/app/src/main/java/com/teobaranga/monica/contacts/detail/activities/edit/domain/Activity.kt
@@ -1,0 +1,11 @@
+package com.teobaranga.monica.contacts.detail.activities.edit.domain
+
+import com.teobaranga.monica.contacts.detail.activities.edit.ui.ActivityParticipant
+import java.time.LocalDate
+
+data class Activity(
+    val summary: String,
+    val details: String?,
+    val date: LocalDate,
+    val participants: List<ActivityParticipant>,
+)

--- a/app/src/main/java/com/teobaranga/monica/contacts/detail/activities/edit/domain/GetActivityUseCase.kt
+++ b/app/src/main/java/com/teobaranga/monica/contacts/detail/activities/edit/domain/GetActivityUseCase.kt
@@ -1,0 +1,28 @@
+package com.teobaranga.monica.contacts.detail.activities.edit.domain
+
+import com.teobaranga.monica.activities.data.ContactActivitiesRepository
+import com.teobaranga.monica.core.dispatcher.Dispatcher
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+internal class GetActivityUseCase @Inject constructor(
+    private val dispatcher: Dispatcher,
+    private val contactActivitiesRepository: ContactActivitiesRepository,
+    private val mapContactToActivityParticipant: MapContactToActivityParticipant,
+) {
+
+    suspend operator fun invoke(activityId: Int): Activity {
+        return withContext(dispatcher.io) {
+            val activity = contactActivitiesRepository.getActivity(activityId).first()
+            Activity(
+                summary = activity.activity.title,
+                details = activity.activity.description,
+                date = activity.activity.date,
+                participants = activity.participants.map { contact ->
+                    mapContactToActivityParticipant(contact)
+                },
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/teobaranga/monica/contacts/detail/activities/edit/domain/MapContactToActivityParticipant.kt
+++ b/app/src/main/java/com/teobaranga/monica/contacts/detail/activities/edit/domain/MapContactToActivityParticipant.kt
@@ -1,0 +1,17 @@
+package com.teobaranga.monica.contacts.detail.activities.edit.domain
+
+import com.teobaranga.monica.contacts.data.ContactEntity
+import com.teobaranga.monica.contacts.detail.activities.edit.ui.ActivityParticipant
+import com.teobaranga.monica.contacts.list.userAvatar
+import javax.inject.Inject
+
+class MapContactToActivityParticipant @Inject constructor() {
+
+    operator fun invoke(contact: ContactEntity): ActivityParticipant {
+        return ActivityParticipant(
+            contactId = contact.contactId,
+            name = contact.completeName,
+            avatar = contact.userAvatar,
+        )
+    }
+}

--- a/app/src/main/java/com/teobaranga/monica/contacts/detail/activities/edit/domain/SearchContactAsActivityParticipantUseCase.kt
+++ b/app/src/main/java/com/teobaranga/monica/contacts/detail/activities/edit/domain/SearchContactAsActivityParticipantUseCase.kt
@@ -1,0 +1,22 @@
+package com.teobaranga.monica.contacts.detail.activities.edit.domain
+
+import com.teobaranga.monica.contacts.detail.activities.edit.ui.ActivityParticipant
+import com.teobaranga.monica.contacts.domain.SearchContactUseCase
+import com.teobaranga.monica.core.dispatcher.Dispatcher
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+internal class SearchContactAsActivityParticipantUseCase @Inject constructor(
+    private val dispatcher: Dispatcher,
+    private val searchContactUseCase: SearchContactUseCase,
+    private val mapContactToActivityParticipant: MapContactToActivityParticipant,
+) {
+    suspend operator fun invoke(query: String, excludeContacts: List<Int> = emptyList()): List<ActivityParticipant> {
+        return withContext(dispatcher.io) {
+            searchContactUseCase(query, excludeContacts)
+                .map { contact ->
+                    mapContactToActivityParticipant(contact)
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/teobaranga/monica/contacts/detail/activities/edit/ui/EditContactActivityScreen.kt
+++ b/app/src/main/java/com/teobaranga/monica/contacts/detail/activities/edit/ui/EditContactActivityScreen.kt
@@ -45,6 +45,7 @@ import com.teobaranga.monica.ui.FabPadding
 import com.teobaranga.monica.ui.button.DateButton
 import com.teobaranga.monica.ui.plus
 import com.teobaranga.monica.ui.theme.MonicaTheme
+import kotlinx.coroutines.flow.MutableStateFlow
 import java.time.LocalDate
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -276,6 +277,7 @@ private fun PreviewEditContactActivityLoadedScreen() {
         EditContactActivity(
             uiState = EditContactActivityUiState.Loaded(
                 onParticipantSearch = { },
+                participantResults = MutableStateFlow(emptyList()),
             ),
             topAppBar = { },
             onSave = { },

--- a/app/src/main/java/com/teobaranga/monica/contacts/detail/activities/edit/ui/EditContactActivityUiState.kt
+++ b/app/src/main/java/com/teobaranga/monica/contacts/detail/activities/edit/ui/EditContactActivityUiState.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.text.input.TextFieldValue
+import kotlinx.coroutines.flow.StateFlow
 import java.time.LocalDate
 
 sealed interface EditContactActivityUiState {
@@ -15,14 +16,13 @@ sealed interface EditContactActivityUiState {
     @Stable
     data class Loaded(
         private val onParticipantSearch: (String) -> Unit,
+        val participantResults: StateFlow<List<ActivityParticipant>>,
     ) : EditContactActivityUiState {
 
-        var date by mutableStateOf(LocalDate.now())
+        var date: LocalDate by mutableStateOf(LocalDate.now())
 
         var participantSearch by mutableStateOf(TextFieldValue())
             private set
-
-        val participantResults = mutableStateListOf<ActivityParticipant>()
 
         val participants = mutableStateListOf<ActivityParticipant>()
 

--- a/app/src/main/java/com/teobaranga/monica/contacts/detail/activities/edit/ui/ParticipantsSection.kt
+++ b/app/src/main/java/com/teobaranga/monica/contacts/detail/activities/edit/ui/ParticipantsSection.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupProperties
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.teobaranga.monica.ui.avatar.UserAvatar
 import kotlinx.coroutines.launch
 
@@ -66,6 +67,8 @@ fun ParticipantsSection(uiState: EditContactActivityUiState.Loaded, modifier: Mo
                 expanded = it
             },
         ) {
+            val participantResults by uiState.participantResults.collectAsStateWithLifecycle()
+
             OutlinedTextField(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -90,12 +93,12 @@ fun ParticipantsSection(uiState: EditContactActivityUiState.Loaded, modifier: Mo
                 modifier = Modifier
                     .exposedDropdownSize(true),
                 properties = PopupProperties(focusable = false),
-                expanded = uiState.participantResults.isNotEmpty(),
+                expanded = participantResults.isNotEmpty(),
                 onDismissRequest = {
                     expanded = false
                 },
             ) {
-                uiState.participantResults.forEach { result ->
+                participantResults.forEach { result ->
                     DropdownMenuItem(
                         text = {
                             Text(text = result.name)

--- a/app/src/main/java/com/teobaranga/monica/contacts/domain/GetContactUseCase.kt
+++ b/app/src/main/java/com/teobaranga/monica/contacts/domain/GetContactUseCase.kt
@@ -1,0 +1,19 @@
+package com.teobaranga.monica.contacts.domain
+
+import com.teobaranga.monica.contacts.data.ContactEntity
+import com.teobaranga.monica.contacts.data.ContactRepository
+import com.teobaranga.monica.core.dispatcher.Dispatcher
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+internal class GetContactUseCase @Inject constructor(
+    private val dispatcher: Dispatcher,
+    private val contactRepository: ContactRepository,
+) {
+    suspend operator fun invoke(contactId: Int): ContactEntity {
+        return withContext(dispatcher.io) {
+            contactRepository.getContact(contactId).first()
+        }
+    }
+}

--- a/app/src/main/java/com/teobaranga/monica/contacts/domain/SearchContactUseCase.kt
+++ b/app/src/main/java/com/teobaranga/monica/contacts/domain/SearchContactUseCase.kt
@@ -1,0 +1,20 @@
+package com.teobaranga.monica.contacts.domain
+
+import com.teobaranga.monica.contacts.data.ContactEntity
+import com.teobaranga.monica.contacts.data.ContactRepository
+import com.teobaranga.monica.core.dispatcher.Dispatcher
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+internal class SearchContactUseCase @Inject constructor(
+    private val dispatcher: Dispatcher,
+    private val contactRepository: ContactRepository,
+) {
+    suspend operator fun invoke(query: String, excludeContacts: List<Int> = emptyList()): List<ContactEntity> {
+        return withContext(dispatcher.io) {
+            val trimmedQuery = query.trim().takeIf { it.isNotBlank() }
+                ?: return@withContext emptyList()
+            contactRepository.searchContact(trimmedQuery, excludeContacts)
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/com/teobaranga/monica/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/teobaranga/monica/KotlinAndroid.kt
@@ -92,6 +92,8 @@ private inline fun <reified T : KotlinTopLevelExtension> Project.configureKotlin
         freeCompilerArgs.addAll(
             "-Xcontext-receivers",
             "-opt-in=kotlin.uuid.ExperimentalUuidApi",
+            "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+            "-opt-in=kotlinx.coroutines.FlowPreview",
         )
     }
 }


### PR DESCRIPTION
The flickering happened because there was no debounce on the search input and the results were cleared for too long before the new results came in.

There is now a debounce of 200ms along with other improvements:
- the UI state production only kicks in after collecting it instead of launching on ViewModel init
- the participant search logic has been separated into usecases and the filtering has been offloaded to Room for better performance