### PR TITLE
fix(journal): improve animations

### DIFF
--- a/app/src/main/java/com/teobaranga/monica/journal/list/JournalEntryList.kt
+++ b/app/src/main/java/com/teobaranga/monica/journal/list/JournalEntryList.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -15,8 +14,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.ramcosta.composedestinations.annotation.Destination
@@ -80,10 +77,4 @@ internal fun JournalEntryList(
             navigator.navigate(JournalEntryDestination())
         },
     )
-    val state by LocalLifecycleOwner.current.lifecycle.currentStateFlow.collectAsStateWithLifecycle()
-    LaunchedEffect(state) {
-        if (state == Lifecycle.State.RESUMED) {
-            viewModel.onEntriesChanged()
-        }
-    }
 }

--- a/app/src/main/java/com/teobaranga/monica/journal/list/JournalEntryListViewModel.kt
+++ b/app/src/main/java/com/teobaranga/monica/journal/list/JournalEntryListViewModel.kt
@@ -2,15 +2,12 @@ package com.teobaranga.monica.journal.list
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.paging.Pager
-import androidx.paging.PagingConfig
 import androidx.paging.cachedIn
 import androidx.paging.map
 import com.teobaranga.monica.core.dispatcher.Dispatcher
 import com.teobaranga.monica.data.sync.Synchronizer
 import com.teobaranga.monica.data.user.UserRepository
 import com.teobaranga.monica.journal.data.JournalEntrySynchronizer
-import com.teobaranga.monica.journal.data.JournalPagingSource
 import com.teobaranga.monica.journal.data.JournalRepository
 import com.teobaranga.monica.journal.database.JournalEntryEntity
 import com.teobaranga.monica.journal.list.ui.JournalEntryListItem
@@ -21,22 +18,19 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-
-private const val PAGE_SIZE = 15
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 internal class JournalEntryListViewModel @Inject constructor(
     private val dispatcher: Dispatcher,
     userRepository: UserRepository,
-    private val journalRepository: JournalRepository,
+    journalRepository: JournalRepository,
     private val journalEntrySynchronizer: JournalEntrySynchronizer,
 ) : ViewModel() {
-
-    private lateinit var pagingSource: JournalPagingSource
 
     val userAvatar = userRepository.me
         .mapLatest { me ->
@@ -48,20 +42,7 @@ internal class JournalEntryListViewModel @Inject constructor(
             started = SharingStarted.WhileSubscribed(5_000),
         )
 
-    val items = Pager(
-        config = PagingConfig(
-            pageSize = PAGE_SIZE,
-            enablePlaceholders = false,
-            initialLoadSize = PAGE_SIZE,
-        ),
-        pagingSourceFactory = {
-            pagingSource = journalRepository.getJournalEntries(
-                orderBy = JournalRepository.OrderBy.Date(isAscending = false),
-            )
-            pagingSource
-        },
-    )
-        .flow
+    val items = journalRepository.getJournalEntriesPagingData()
         .mapLatest { pagingData ->
             pagingData.map { journalEntryEntity ->
                 journalEntryEntity.toUiModel()
@@ -71,6 +52,9 @@ internal class JournalEntryListViewModel @Inject constructor(
 
     private val _refreshState = MonicaPullToRefreshState(onRefresh = ::refresh)
     val refreshState = journalEntrySynchronizer.syncState
+        .onStart {
+            refresh()
+        }
         .mapLatest { state ->
             state == Synchronizer.State.REFRESHING
         }
@@ -85,18 +69,10 @@ internal class JournalEntryListViewModel @Inject constructor(
             started = SharingStarted.WhileSubscribed(5_000),
         )
 
-    init {
-        refresh()
-    }
-
     private fun refresh() {
         viewModelScope.launch(dispatcher.io) {
             journalEntrySynchronizer.sync()
         }
-    }
-
-    fun onEntriesChanged() {
-        pagingSource.invalidate()
     }
 
     private fun JournalEntryEntity.toUiModel(): JournalEntryListItem {

--- a/app/src/main/java/com/teobaranga/monica/util/compose/KeepScrollOnSizeChangedModifier.kt
+++ b/app/src/main/java/com/teobaranga/monica/util/compose/KeepScrollOnSizeChangedModifier.kt
@@ -1,0 +1,50 @@
+package com.teobaranga.monica.util.compose
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.unit.IntSize
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.onEach
+
+@Composable
+fun Modifier.keepScrollOnSizeChanged(lazyListState: LazyListState): Modifier {
+    var offset by rememberSaveable { mutableIntStateOf(lazyListState.firstVisibleItemScrollOffset) }
+    var size by remember { mutableStateOf<IntSize?>(null) }
+    var prevSize by remember { mutableStateOf(size) }
+    // Restore the offset when the screen is resumed, only as it is shrinking
+    LaunchedEffect(Unit) {
+        snapshotFlow { size }
+            .filterNotNull()
+            .onEach { newSize ->
+                val isShrinking = newSize.height < (prevSize?.height ?: Int.MAX_VALUE)
+                if (isShrinking) {
+                    with(lazyListState) {
+                        dispatchRawDelta((offset - firstVisibleItemScrollOffset).toFloat())
+                    }
+                }
+                prevSize = newSize
+            }
+            .collect()
+    }
+    LifecycleEventEffect(Lifecycle.Event.ON_PAUSE) {
+        // Save the current offset when the screen is paused
+        offset = lazyListState.firstVisibleItemScrollOffset
+    }
+    return this then Modifier
+        .onSizeChanged { newSize ->
+            size = newSize
+        }
+}

--- a/app/src/main/java/com/teobaranga/monica/util/compose/ScrollToTopEffect.kt
+++ b/app/src/main/java/com/teobaranga/monica/util/compose/ScrollToTopEffect.kt
@@ -1,0 +1,34 @@
+package com.teobaranga.monica.util.compose
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+@Composable
+fun ScrollToTopEffect(
+    lazyListState: LazyListState,
+    getFirstId: () -> Int?,
+) {
+    var prevId by rememberSaveable { mutableStateOf<Int?>(null) }
+    val coroutineScope = rememberCoroutineScope()
+    LifecycleEventEffect(Lifecycle.Event.ON_PAUSE) {
+        prevId = getFirstId()
+    }
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        val firstId = getFirstId()
+        if (prevId != null && prevId != firstId) {
+            coroutineScope.launch {
+                delay(250)
+                lazyListState.animateScrollToItem(0)
+            }
+        }
+    }
+}


### PR DESCRIPTION
- added item animations to the list for when items are added or removed
- sync the scroll position with the nav bar shrinking. The list position is now the same after tapping on an item and coming back to the list.
- scroll to the top when an item has been added to the beginning of the list
- invalidate the paging data from the repository