### PR TITLE
improve code quality around various areas

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,4 +12,8 @@ ktlint_standard_function-expression-body = disabled
 # Disable the class-signature rule
 # Rationale: the decision for a single or multiline class signature is context dependent
 ktlint_standard_class-signature = disabled
+# Disable the function signature rule
+# Rationale: the function signature sometimes looks better in a single line and sometimes in a multiline, irrespective
+# of the number of parameters.
+ktlint_standard_function-signature = disabled
 max_line_length = 120

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
 plugins {
     alias(libs.plugins.monica.android.application)
@@ -121,4 +122,7 @@ ktlint {
     android = true
     verbose = true
     version = "1.3.1"
+    reporters {
+        reporter(ReporterType.HTML)
+    }
 }

--- a/app/src/main/java/com/teobaranga/monica/contacts/detail/activities/edit/ui/EditContactActivityScreen.kt
+++ b/app/src/main/java/com/teobaranga/monica/contacts/detail/activities/edit/ui/EditContactActivityScreen.kt
@@ -43,13 +43,14 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
-import com.teobaranga.monica.journal.view.ui.StartVerticalLineShape
 import com.teobaranga.monica.ui.FabHeight
 import com.teobaranga.monica.ui.FabPadding
 import com.teobaranga.monica.ui.Zero
 import com.teobaranga.monica.ui.button.DateButton
 import com.teobaranga.monica.ui.navigation.LocalDestinationsNavigator
 import com.teobaranga.monica.ui.text.MonicaTextField
+import com.teobaranga.monica.ui.text.MonicaTextFieldDefaults
+import com.teobaranga.monica.ui.text.startVerticalLineShape
 import com.teobaranga.monica.ui.theme.MonicaTheme
 import com.teobaranga.monica.util.compose.CursorData
 import com.teobaranga.monica.util.compose.CursorVisibilityStrategy
@@ -217,7 +218,7 @@ private fun SummarySection(uiState: EditContactActivityUiState.Loaded, modifier:
                 .padding(horizontal = 24.dp)
                 .padding(top = 12.dp),
             interactionSource = interactionSource,
-            shape = StartVerticalLineShape(interactionSource),
+            shape = MonicaTextFieldDefaults.startVerticalLineShape(interactionSource),
             state = uiState.summary,
             placeholder = {
                 Text(
@@ -260,7 +261,7 @@ private fun DetailsSection(
             state = textFieldState,
             onTextLayout = cursorData.textLayoutResult,
             interactionSource = interactionSource,
-            shape = StartVerticalLineShape(interactionSource),
+            shape = MonicaTextFieldDefaults.startVerticalLineShape(interactionSource),
             placeholder = {
                 Text(
                     text = "Add more details (optional)",

--- a/app/src/main/java/com/teobaranga/monica/contacts/detail/activities/edit/ui/ParticipantsSection.kt
+++ b/app/src/main/java/com/teobaranga/monica/contacts/detail/activities/edit/ui/ParticipantsSection.kt
@@ -45,10 +45,11 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.ramcosta.composedestinations.generated.destinations.ContactEditDestination
-import com.teobaranga.monica.journal.view.ui.StartVerticalLineShape
 import com.teobaranga.monica.ui.avatar.UserAvatar
 import com.teobaranga.monica.ui.navigation.LocalDestinationsNavigator
 import com.teobaranga.monica.ui.text.MonicaTextField
+import com.teobaranga.monica.ui.text.MonicaTextFieldDefaults
+import com.teobaranga.monica.ui.text.startVerticalLineShape
 import kotlinx.coroutines.launch
 
 @Composable
@@ -107,7 +108,7 @@ private fun ParticipantDropdownMenu(
                 .menuAnchor(type = MenuAnchorType.PrimaryEditable),
             state = uiState.participantSearch,
             interactionSource = interactionSource,
-            shape = StartVerticalLineShape(interactionSource),
+            shape = MonicaTextFieldDefaults.startVerticalLineShape(interactionSource),
             placeholder = {
                 Text(
                     text = "Add a participant by name",

--- a/app/src/main/java/com/teobaranga/monica/journal/list/ui/JournalEntryListScreen.kt
+++ b/app/src/main/java/com/teobaranga/monica/journal/list/ui/JournalEntryListScreen.kt
@@ -106,7 +106,7 @@ fun JournalEntryListScreen(
                         is LoadState.NotLoading,
                         -> {
                             items(
-                                items =  lazyItems.itemSnapshotList,
+                                items = lazyItems.itemSnapshotList,
                                 key = { journalEntry ->
                                     journalEntry?.id ?: Int.MIN_VALUE
                                 },

--- a/app/src/main/java/com/teobaranga/monica/journal/view/ui/JournalEntryScreen.kt
+++ b/app/src/main/java/com/teobaranga/monica/journal/view/ui/JournalEntryScreen.kt
@@ -36,6 +36,8 @@ import com.teobaranga.monica.ui.Zero
 import com.teobaranga.monica.ui.button.DateButton
 import com.teobaranga.monica.ui.rememberConfirmExitDialogState
 import com.teobaranga.monica.ui.text.MonicaTextField
+import com.teobaranga.monica.ui.text.MonicaTextFieldDefaults
+import com.teobaranga.monica.ui.text.startVerticalLineShape
 import com.teobaranga.monica.ui.theme.MonicaTheme
 import com.teobaranga.monica.util.compose.CursorVisibilityStrategy
 import com.teobaranga.monica.util.compose.keepCursorVisible
@@ -134,7 +136,7 @@ fun JournalEntryScreen(
                                 )
                             },
                             lineLimits = TextFieldLineLimits.SingleLine,
-                            shape = StartVerticalLineShape(titleInteractionSource),
+                            shape = MonicaTextFieldDefaults.startVerticalLineShape(titleInteractionSource),
                             keyboardOptions = KeyboardOptions(
                                 capitalization = KeyboardCapitalization.Sentences,
                                 autoCorrectEnabled = true,
@@ -164,7 +166,7 @@ fun JournalEntryScreen(
                                     style = MaterialTheme.typography.bodyMedium,
                                 )
                             },
-                            shape = StartVerticalLineShape(postInteractionSource),
+                            shape = MonicaTextFieldDefaults.startVerticalLineShape(postInteractionSource),
                             keyboardOptions = KeyboardOptions(
                                 capitalization = KeyboardCapitalization.Sentences,
                                 autoCorrectEnabled = true,

--- a/app/src/main/java/com/teobaranga/monica/journal/view/ui/JournalEntryUiState.kt
+++ b/app/src/main/java/com/teobaranga/monica/journal/view/ui/JournalEntryUiState.kt
@@ -26,9 +26,9 @@ sealed interface JournalEntryUiState {
         val post = TextFieldState(initialPost)
 
         val hasChanges by derivedStateOf {
-            initialTitle.orEmpty() != title.text
-                || initialPost != post.text
-                || initialDate != date
+            initialTitle.orEmpty() != title.text ||
+                initialPost != post.text ||
+                initialDate != date
         }
 
         override fun equals(other: Any?): Boolean {

--- a/app/src/main/java/com/teobaranga/monica/ui/text/MonicaTextFieldDefaults.kt
+++ b/app/src/main/java/com/teobaranga/monica/ui/text/MonicaTextFieldDefaults.kt
@@ -1,0 +1,6 @@
+package com.teobaranga.monica.ui.text
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+object MonicaTextFieldDefaults

--- a/app/src/main/java/com/teobaranga/monica/ui/text/StartVerticalLineShape.kt
+++ b/app/src/main/java/com/teobaranga/monica/ui/text/StartVerticalLineShape.kt
@@ -1,4 +1,4 @@
-package com.teobaranga.monica.journal.view.ui
+package com.teobaranga.monica.ui.text
 
 import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
@@ -36,7 +36,7 @@ private class StartVerticalLineShape(val isFocused: () -> Boolean) : Shape {
 }
 
 @Composable
-fun StartVerticalLineShape(interactionSource: InteractionSource): Shape {
+fun MonicaTextFieldDefaults.startVerticalLineShape(interactionSource: InteractionSource): Shape {
     val isFocused by interactionSource.collectIsFocusedAsState()
     return StartVerticalLineShape(isFocused = { isFocused })
 }


### PR DESCRIPTION
- Use `MonicaTextFieldDefaults.startVerticalLineShape` instead of `StartVerticalLineShape` to be more consistent with Material style and avoid a capitalised non-UI-emitting Compose method
- Refactor UI state building in `JournalEntryViewModel` to simplify logic and avoid a lint-problematic `when` statement
- Disable `function-signature` rule for the same reason as `class-signature`