### PR TITLE
feat(avatar): darken avatar backgrounds in dark mode

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -92,6 +92,8 @@ dependencies {
 
     implementation(libs.datastore.preferences)
 
+    implementation(libs.material.kolor)
+
     implementation(libs.paging.runtime)
     implementation(libs.paging.compose)
 

--- a/app/src/main/java/com/teobaranga/monica/ui/avatar/UserAvatar.kt
+++ b/app/src/main/java/com/teobaranga/monica/ui/avatar/UserAvatar.kt
@@ -1,5 +1,6 @@
 package com.teobaranga.monica.ui.avatar
 
+import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -14,12 +15,16 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.graphics.toColorInt
 import coil.compose.AsyncImagePainter
 import coil.compose.SubcomposeAsyncImage
 import coil.compose.SubcomposeAsyncImageContent
 import coil.request.ImageRequest
+import com.materialkolor.ktx.darken
+import com.teobaranga.monica.ui.theme.MonicaTheme
+import com.teobaranga.monica.util.compose.fromHex
+import com.teobaranga.monica.util.compose.isLight
 
 data class UserAvatar(
     val contactId: Int,
@@ -34,7 +39,13 @@ fun UserAvatar(userAvatar: UserAvatar, modifier: Modifier = Modifier, onClick: (
         modifier = modifier
             .size(32.dp)
             .clip(CircleShape)
-            .background(Color(userAvatar.color.toColorInt()))
+            .background(
+                Color.fromHex(userAvatar.color).run {
+                    // Some colours don't have enough contrast in dark mode, darken them
+                    val isLight = MaterialTheme.colorScheme.isLight()
+                    if (isLight) this else darken(2.5f)
+                },
+            )
             .then(
                 if (onClick != null) {
                     Modifier.clickable(onClick = onClick)
@@ -67,5 +78,20 @@ fun UserAvatar(userAvatar: UserAvatar, modifier: Modifier = Modifier, onClick: (
                 )
             }
         }
+    }
+}
+
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun PreviewUserAvatar() {
+    MonicaTheme {
+        UserAvatar(
+            userAvatar = UserAvatar(
+                contactId = 1,
+                initials = "TB",
+                color = "#709512",
+                avatarUrl = null,
+            ),
+        )
     }
 }

--- a/app/src/main/java/com/teobaranga/monica/util/compose/ColorEx.kt
+++ b/app/src/main/java/com/teobaranga/monica/util/compose/ColorEx.kt
@@ -1,0 +1,21 @@
+package com.teobaranga.monica.util.compose
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+
+/**
+ * Parse a [Color] from a color hex string, such as #FF000080.
+ */
+fun Color.Companion.fromHex(hexColor: String): Color {
+    return Color(hexColor.removePrefix("#").toLong(16) or 0x00000000FF000000)
+}
+
+/**
+ * Determine if this is a light theme based on the background luminance value.
+ */
+@Composable
+fun ColorScheme.isLight(): Boolean {
+    return background.luminance() > 0.5
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ hilt-navigation-compose = "1.2.0"
 hilt-work = "1.2.0"
 junit = "4.13.2"
 kotlinx-coroutines = "1.9.0"
+materialKolor = "2.0.0"
 moshi = "1.15.1"
 moshi-converter = "2.11.0"
 moshix = "0.28.0"
@@ -69,6 +70,7 @@ hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hilt-w
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+material-kolor = { module = "com.materialkolor:material-kolor", version.ref = "materialKolor" }
 moshi-adapters = { group = "com.squareup.moshi", name = "moshi-adapters", version.ref = "moshi" }
 moshi-converter = { group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "moshi-converter" }
 moshi-kotlin-codegen = { group = "com.squareup.moshi", name = "moshi-kotlin-codegen", version.ref = "moshi" }


### PR DESCRIPTION
The avatar colours coming down from Monica can be very bright and contrast too much with the screen's dark background. Additionally, the initials are light-coloured so the background should be dark enough for the text to be readable.

These changes apply the `darken` function from material-kolor in order to get a darker avatar background.