### PR TITLE
feat(test): add BDD unit tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -111,8 +111,11 @@ dependencies {
     implementation(libs.work)
     implementation(libs.hilt.work)
 
+    testImplementation(libs.kotest.runner.junit5)
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+
+    testImplementation(libs.turbine)
 
     androidTestImplementation(libs.androidx.test.ext.junit)
     androidTestImplementation(libs.espresso.core)
@@ -127,4 +130,8 @@ ktlint {
     reporters {
         reporter(ReporterType.HTML)
     }
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
 }

--- a/app/src/main/java/com/teobaranga/monica/MonicaApp.kt
+++ b/app/src/main/java/com/teobaranga/monica/MonicaApp.kt
@@ -3,10 +3,10 @@ package com.teobaranga.monica
 import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
-import androidx.work.WorkManager
 import coil.ImageLoader
 import coil.ImageLoaderFactory
 import com.teobaranga.monica.sync.SyncWorker
+import com.teobaranga.monica.work.WorkScheduler
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
 import javax.inject.Inject
@@ -22,17 +22,17 @@ class MonicaApp : Application(), ImageLoaderFactory, Configuration.Provider {
     lateinit var imageLoader: Provider<ImageLoader>
 
     @Inject
-    lateinit var workerFactory: HiltWorkerFactory
+    lateinit var hiltWorkerFactory: HiltWorkerFactory
 
     @Inject
-    lateinit var workManager: WorkManager
+    lateinit var workScheduler: WorkScheduler
 
     override fun onCreate() {
         super.onCreate()
 
         Timber.plant(*timberTrees.toTypedArray())
 
-        SyncWorker.enqueue(workManager)
+        workScheduler.schedule(SyncWorker.WORK_NAME)
     }
 
     override fun newImageLoader(): ImageLoader {
@@ -41,6 +41,6 @@ class MonicaApp : Application(), ImageLoaderFactory, Configuration.Provider {
 
     override val workManagerConfiguration: Configuration
         get() = Configuration.Builder()
-            .setWorkerFactory(workerFactory)
+            .setWorkerFactory(hiltWorkerFactory)
             .build()
 }

--- a/app/src/main/java/com/teobaranga/monica/setup/domain/SignInUseCase.kt
+++ b/app/src/main/java/com/teobaranga/monica/setup/domain/SignInUseCase.kt
@@ -3,7 +3,6 @@ package com.teobaranga.monica.setup.domain
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
-import androidx.work.WorkManager
 import com.skydoves.sandwich.getOrNull
 import com.skydoves.sandwich.onFailure
 import com.teobaranga.monica.core.dispatcher.Dispatcher
@@ -11,6 +10,7 @@ import com.teobaranga.monica.data.MonicaApi
 import com.teobaranga.monica.data.TokenRequest
 import com.teobaranga.monica.settings.tokenStorage
 import com.teobaranga.monica.sync.SyncWorker
+import com.teobaranga.monica.work.WorkScheduler
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import javax.inject.Inject
@@ -19,7 +19,7 @@ class SignInUseCase @Inject internal constructor(
     private val dispatcher: Dispatcher,
     private val monicaApi: MonicaApi,
     private val dataStore: DataStore<Preferences>,
-    private val workManager: WorkManager,
+    private val workScheduler: WorkScheduler,
 ) {
 
     suspend operator fun invoke(clientId: String, clientSecret: String, authorizationCode: String): Boolean {
@@ -41,7 +41,7 @@ class SignInUseCase @Inject internal constructor(
             }
 
             // Trigger a sync which loads the current user and any other data
-            SyncWorker.enqueue(workManager)
+            workScheduler.schedule(SyncWorker.WORK_NAME)
 
             true
         }

--- a/app/src/main/java/com/teobaranga/monica/sync/SyncUseCase.kt
+++ b/app/src/main/java/com/teobaranga/monica/sync/SyncUseCase.kt
@@ -1,0 +1,40 @@
+package com.teobaranga.monica.sync
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.work.ListenableWorker
+import com.teobaranga.monica.account.AccountListener
+import com.teobaranga.monica.data.user.UserRepository
+import com.teobaranga.monica.genders.data.GenderRepository
+import com.teobaranga.monica.settings.getTokenStorage
+import jakarta.inject.Inject
+import kotlinx.coroutines.flow.first
+import timber.log.Timber
+
+internal class SyncUseCase @Inject constructor(
+    private val dataStore: DataStore<Preferences>,
+    private val userRepository: UserRepository,
+    private val genderRepository: GenderRepository,
+    private val accountListeners: Set<@JvmSuppressWildcards AccountListener>,
+) {
+    suspend operator fun invoke(): ListenableWorker.Result {
+        val isTokenAvailable = dataStore.data.first().getTokenStorage().accessToken != null
+        if (!isTokenAvailable) {
+            Timber.d("Access token not available, skipping sync")
+            return ListenableWorker.Result.success()
+        }
+
+        accountListeners.forEach { accountListener ->
+            accountListener.onSignedIn()
+        }
+
+        Timber.d("Syncing current user")
+        userRepository.sync()
+
+        Timber.d("Syncing genders")
+        // TODO is this the best place? probably not
+        genderRepository.fetchLatestGenders()
+
+        return ListenableWorker.Result.success()
+    }
+}

--- a/app/src/main/java/com/teobaranga/monica/work/WorkManagerWorkScheduler.kt
+++ b/app/src/main/java/com/teobaranga/monica/work/WorkManagerWorkScheduler.kt
@@ -1,0 +1,17 @@
+package com.teobaranga.monica.work
+
+import androidx.work.WorkManager
+import com.teobaranga.monica.sync.SyncWorker
+import javax.inject.Inject
+
+class WorkManagerWorkScheduler @Inject constructor(
+    private val workManager: WorkManager,
+) : WorkScheduler {
+
+    override fun schedule(workName: String) {
+        when (workName) {
+            SyncWorker.WORK_NAME -> SyncWorker.enqueue(workManager)
+            else -> error("Unknown work name: $workName")
+        }
+    }
+}

--- a/app/src/main/java/com/teobaranga/monica/work/WorkModule.kt
+++ b/app/src/main/java/com/teobaranga/monica/work/WorkModule.kt
@@ -1,0 +1,14 @@
+package com.teobaranga.monica.work
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class WorkModule {
+
+    @Binds
+    abstract fun bindWorkScheduler(workManagerWorkScheduler: WorkManagerWorkScheduler): WorkScheduler
+}

--- a/app/src/main/java/com/teobaranga/monica/work/WorkScheduler.kt
+++ b/app/src/main/java/com/teobaranga/monica/work/WorkScheduler.kt
@@ -1,0 +1,6 @@
+package com.teobaranga.monica.work
+
+interface WorkScheduler {
+
+    fun schedule(workName: String)
+}

--- a/app/src/test/java/com/teobaranga/monica/TestDispatcher.kt
+++ b/app/src/test/java/com/teobaranga/monica/TestDispatcher.kt
@@ -3,9 +3,11 @@ package com.teobaranga.monica
 import com.teobaranga.monica.core.dispatcher.Dispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class TestDispatcher : Dispatcher {
+class TestDispatcher @Inject constructor() : Dispatcher {
     override val main = UnconfinedTestDispatcher()
     override val io = UnconfinedTestDispatcher()
+    override val default = UnconfinedTestDispatcher()
 }

--- a/app/src/test/java/com/teobaranga/monica/auth/FakeAuthorizationRepository.kt
+++ b/app/src/test/java/com/teobaranga/monica/auth/FakeAuthorizationRepository.kt
@@ -2,23 +2,18 @@ package com.teobaranga.monica.auth
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 class FakeAuthorizationRepository : AuthorizationRepository {
 
-    private var _isLoggedIn: Boolean? = null
-
-    override val isLoggedIn: StateFlow<Boolean?>
-        get() = MutableStateFlow(_isLoggedIn)
+    private var _isLoggedIn = MutableStateFlow(false)
+    override val isLoggedIn: StateFlow<Boolean?> = _isLoggedIn.asStateFlow()
 
     fun logIn() {
-        _isLoggedIn = true
+        _isLoggedIn.value = true
     }
 
     fun logOut() {
-        _isLoggedIn = false
-    }
-
-    override suspend fun signIn(clientId: String, clientSecret: String, authorizationCode: String): Boolean {
-        return false
+        _isLoggedIn.value = false
     }
 }

--- a/app/src/test/java/com/teobaranga/monica/data/DataStoreModule.kt
+++ b/app/src/test/java/com/teobaranga/monica/data/DataStoreModule.kt
@@ -1,0 +1,13 @@
+package com.teobaranga.monica.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import dagger.Binds
+import dagger.Module
+
+@Module
+abstract class DataStoreModule {
+
+    @Binds
+    abstract fun providePreferencesDataStore(dataStore: TestDataStore): DataStore<Preferences>
+}

--- a/app/src/test/java/com/teobaranga/monica/data/TestDataStore.kt
+++ b/app/src/test/java/com/teobaranga/monica/data/TestDataStore.kt
@@ -1,0 +1,50 @@
+package com.teobaranga.monica.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import com.teobaranga.monica.core.dispatcher.Dispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TestDataStore @Inject constructor(
+    private val dispatcher: Dispatcher,
+) : DataStore<Preferences> {
+
+    private val file = File("test.preferences_pb")
+
+    private lateinit var prevScope: CoroutineScope
+
+    private lateinit var dataStore: DataStore<Preferences>
+
+    init {
+        reset()
+    }
+
+    override val data: Flow<Preferences>
+        get() = dataStore.data
+
+    override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences {
+        return dataStore.updateData(transform)
+    }
+
+    /**
+     * There can only be one active instance of a DataStore so we want to allow resetting it so that it
+     * can be reused in tests.
+     */
+    fun reset() {
+        if (::prevScope.isInitialized) {
+            prevScope.cancel()
+        }
+        prevScope = CoroutineScope(dispatcher.io + SupervisorJob())
+        dataStore = PreferenceDataStoreFactory.create(scope = prevScope) {
+            file
+        }
+    }
+}

--- a/app/src/test/java/com/teobaranga/monica/data/TestMonicaApi.kt
+++ b/app/src/test/java/com/teobaranga/monica/data/TestMonicaApi.kt
@@ -1,0 +1,25 @@
+package com.teobaranga.monica.data
+
+import com.skydoves.sandwich.ApiResponse
+import dagger.Binds
+import dagger.Module
+import javax.inject.Inject
+
+@Module
+abstract class ApiModule {
+
+    @Binds
+    abstract fun provideApi(api: TestMonicaApi): MonicaApi
+}
+
+class TestMonicaApi @Inject constructor() : MonicaApi {
+
+    override suspend fun getAccessToken(tokenRequest: TokenRequest): ApiResponse<TokenResponse> {
+        return ApiResponse.of {
+            TokenResponse(
+                accessToken = "access_token",
+                refreshToken = "refresh_token",
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/teobaranga/monica/database/TestDaosModule.kt
+++ b/app/src/test/java/com/teobaranga/monica/database/TestDaosModule.kt
@@ -1,0 +1,12 @@
+package com.teobaranga.monica.database
+
+import com.teobaranga.monica.data.user.UserDao
+import dagger.Binds
+import dagger.Module
+
+@Module
+abstract class TestDaosModule {
+
+    @Binds
+    abstract fun bindsUserDao(dao: TestUserDao): UserDao
+}

--- a/app/src/test/java/com/teobaranga/monica/database/TestUserDao.kt
+++ b/app/src/test/java/com/teobaranga/monica/database/TestUserDao.kt
@@ -1,0 +1,31 @@
+package com.teobaranga.monica.database
+
+import com.teobaranga.monica.data.user.MeEntity
+import com.teobaranga.monica.data.user.MeFullDetails
+import com.teobaranga.monica.data.user.UserDao
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TestUserDao @Inject constructor() : UserDao {
+
+    private val me = MutableStateFlow<MeEntity?>(null)
+
+    override fun getMe(): Flow<MeFullDetails?> {
+        return me.map { meEntity ->
+            meEntity?.let {
+                MeFullDetails(
+                    info = it,
+                    contact = null,
+                )
+            }
+        }
+    }
+
+    override suspend fun upsertMe(entity: MeEntity) {
+        me.value = entity
+    }
+}

--- a/app/src/test/java/com/teobaranga/monica/setup/DispatcherModule.kt
+++ b/app/src/test/java/com/teobaranga/monica/setup/DispatcherModule.kt
@@ -1,0 +1,13 @@
+package com.teobaranga.monica.setup
+
+import com.teobaranga.monica.TestDispatcher
+import com.teobaranga.monica.core.dispatcher.Dispatcher
+import dagger.Binds
+import dagger.Module
+
+@Module
+abstract class DispatcherModule {
+
+    @Binds
+    abstract fun provideDispatcher(dispatcher: TestDispatcher): Dispatcher
+}

--- a/app/src/test/java/com/teobaranga/monica/setup/SetupViewModelTest.kt
+++ b/app/src/test/java/com/teobaranga/monica/setup/SetupViewModelTest.kt
@@ -1,114 +1,151 @@
 package com.teobaranga.monica.setup
 
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.lifecycle.SavedStateHandle
-import com.teobaranga.monica.TestDispatcher
-import com.teobaranga.monica.auth.FakeAuthorizationRepository
+import androidx.datastore.preferences.core.edit
+import app.cash.turbine.test
+import com.teobaranga.monica.auth.AuthorizationModule
+import com.teobaranga.monica.data.ApiModule
+import com.teobaranga.monica.data.DataStoreModule
 import com.teobaranga.monica.data.PARAM_CLIENT_ID
 import com.teobaranga.monica.data.PARAM_REDIRECT_URI
 import com.teobaranga.monica.data.PARAM_RESPONSE_TYPE
 import com.teobaranga.monica.data.REDIRECT_URI
-import com.teobaranga.monica.testDataStore
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.runTest
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import com.teobaranga.monica.data.TestDataStore
+import com.teobaranga.monica.data.user.MeEntity
+import com.teobaranga.monica.data.user.UserDao
+import com.teobaranga.monica.database.TestDaosModule
+import com.teobaranga.monica.settings.tokenStorage
+import com.teobaranga.monica.work.TestWorkScheduleModule
+import dagger.Component
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import java.net.URLEncoder
+import javax.inject.Singleton
 
-@OptIn(ExperimentalCoroutinesApi::class)
-class SetupViewModelTest {
-
-    private val savedStateHandle = SavedStateHandle()
-
-    private val dispatcher = TestDispatcher()
-
-    private val dataStore by testDataStore()
-
-    private val authorizationRepository = FakeAuthorizationRepository()
-
-    @Test
-    fun `Given non-http scheme, When sign-in, Then errors out`() = runTest(UnconfinedTestDispatcher()) {
-        val address = "blah"
-        val clientId = "2"
-
-        val viewModel = getViewModel()
-
-        val urls = mutableListOf<String>()
-        backgroundScope.launch {
-            viewModel.setupUri.toList(urls)
-        }
-
-        viewModel.uiState.onServerAddressChanged(TextFieldValue(address))
-        viewModel.uiState.onClientIdChanged(TextFieldValue(clientId))
-
-        viewModel.onSignIn()
-
-        assertEquals(0, urls.size)
-    }
-
-    @Test
-    fun `Given http scheme, When sign-in, Then emits correct URL`() = runTest(UnconfinedTestDispatcher()) {
-        val address = "http://test.com"
-        val clientId = "2"
-
-        val viewModel = getViewModel()
-
-        val urls = mutableListOf<String>()
-        backgroundScope.launch {
-            viewModel.setupUri.toList(urls)
-        }
-
-        viewModel.uiState.onServerAddressChanged(TextFieldValue(address))
-        viewModel.uiState.onClientIdChanged(TextFieldValue(clientId))
-
-        viewModel.onSignIn()
-
-        val redirectUri = URLEncoder.encode(REDIRECT_URI, "UTF-8")
-        assertEquals(
-            "$address/oauth/authorize?" +
-                "$PARAM_CLIENT_ID=$clientId&" +
-                "$PARAM_RESPONSE_TYPE=code&" +
-                "$PARAM_REDIRECT_URI=$redirectUri",
-            urls[0],
-        )
-    }
-
-    @Test
-    fun `Given http scheme with port, When sign-in, Then emits correct URL`() = runTest(UnconfinedTestDispatcher()) {
-        val address = "http://test.com:8080"
-        val clientId = "2"
-
-        val viewModel = getViewModel()
-
-        val urls = mutableListOf<String>()
-        backgroundScope.launch {
-            viewModel.setupUri.toList(urls)
-        }
-
-        viewModel.uiState.onServerAddressChanged(TextFieldValue(address))
-        viewModel.uiState.onClientIdChanged(TextFieldValue(clientId))
-
-        viewModel.onSignIn()
-
-        val redirectUri = URLEncoder.encode(REDIRECT_URI, "UTF-8")
-        assertEquals(
-            "$address/oauth/authorize?" +
-                "$PARAM_CLIENT_ID=$clientId&" +
-                "$PARAM_RESPONSE_TYPE=code&" +
-                "$PARAM_REDIRECT_URI=$redirectUri",
-            urls[0],
-        )
-    }
-
-    private fun getViewModel(): SetupViewModel {
-        return SetupViewModel(
-            savedStateHandle = savedStateHandle,
-            dispatcher = dispatcher,
-            dataStore = dataStore,
-            authorizationRepository = authorizationRepository,
-        )
-    }
+@Component(
+    modules = [
+        ViewModelModule::class,
+        DispatcherModule::class,
+        DataStoreModule::class,
+        AuthorizationModule::class,
+        TestDaosModule::class,
+        ApiModule::class,
+        TestWorkScheduleModule::class,
+    ],
+)
+@Singleton
+interface SetupComponent {
+    fun setupViewModel(): SetupViewModel
+    fun userDao(): UserDao
+    fun dataStore(): TestDataStore
 }
+
+class SetupViewModelTest : BehaviorSpec(
+    {
+        isolationMode = IsolationMode.InstancePerLeaf
+
+        val component = DaggerSetupComponent.create()
+        val viewModel = component.setupViewModel()
+
+        afterTest {
+            component.dataStore().reset()
+        }
+
+        Context("user is not logged in") {
+            viewModel.isLoggedIn.test {
+                awaitItem() shouldNotBeNull { this shouldBe false }
+            }
+
+            Given("a non-http scheme") {
+
+                viewModel.uiState.onServerAddressChanged(TextFieldValue("blah"))
+                viewModel.uiState.onClientIdChanged(TextFieldValue("2"))
+
+                When("I sign in") {
+
+                    viewModel.onSignIn()
+
+                    Then("I get an error") {
+
+                        viewModel.setupUri.test {
+                            expectNoEvents()
+                        }
+                    }
+                }
+            }
+
+            Given("an http scheme") {
+
+                val address = "http://test.com"
+                val clientId = "2"
+                viewModel.uiState.onServerAddressChanged(TextFieldValue(address))
+                viewModel.uiState.onClientIdChanged(TextFieldValue(clientId))
+
+                When("I sign in") {
+
+                    Then("the setup URL is correct") {
+
+                        viewModel.setupUri.test {
+
+                            viewModel.onSignIn()
+
+                            val redirectUri = URLEncoder.encode(REDIRECT_URI, "UTF-8")
+                            awaitItem() shouldBe
+                                "$address/oauth/authorize?" +
+                                "$PARAM_CLIENT_ID=$clientId&" +
+                                "$PARAM_RESPONSE_TYPE=code&" +
+                                "$PARAM_REDIRECT_URI=$redirectUri"
+                        }
+                    }
+                }
+            }
+
+            Given("an http scheme with port") {
+
+                val address = "http://test.com:8080"
+                val clientId = "2"
+                viewModel.uiState.onServerAddressChanged(TextFieldValue(address))
+                viewModel.uiState.onClientIdChanged(TextFieldValue(clientId))
+
+                When("I sign in") {
+
+                    Then("the setup URL is correct") {
+
+                        viewModel.setupUri.test {
+
+                            viewModel.onSignIn()
+
+                            val redirectUri = URLEncoder.encode(REDIRECT_URI, "UTF-8")
+                            awaitItem() shouldBe
+                                "$address/oauth/authorize?" +
+                                "$PARAM_CLIENT_ID=$clientId&" +
+                                "$PARAM_RESPONSE_TYPE=code&" +
+                                "$PARAM_REDIRECT_URI=$redirectUri"
+                        }
+                    }
+                }
+            }
+        }
+
+        Context("user is logged in") {
+
+            component
+                .userDao()
+                .upsertMe(MeEntity(id = 0, firstName = "Teo", contactId = null))
+
+            component
+                .dataStore()
+                .edit {
+                    it.tokenStorage {
+                        setAuthorizationCode("123456")
+                    }
+                }
+
+            viewModel.isLoggedIn.test {
+                awaitItem() shouldNotBeNull { this shouldBe true }
+            }
+        }
+    },
+)

--- a/app/src/test/java/com/teobaranga/monica/setup/ViewModelModule.kt
+++ b/app/src/test/java/com/teobaranga/monica/setup/ViewModelModule.kt
@@ -1,0 +1,12 @@
+package com.teobaranga.monica.setup
+
+import androidx.lifecycle.SavedStateHandle
+import dagger.Module
+import dagger.Provides
+
+@Module
+object ViewModelModule {
+
+    @Provides
+    fun provideSavedStateHandle() = SavedStateHandle()
+}

--- a/app/src/test/java/com/teobaranga/monica/work/TestWorkScheduleModule.kt
+++ b/app/src/test/java/com/teobaranga/monica/work/TestWorkScheduleModule.kt
@@ -1,0 +1,19 @@
+package com.teobaranga.monica.work
+
+import dagger.Binds
+import dagger.Module
+import javax.inject.Inject
+
+class TestWorkScheduler @Inject constructor() : WorkScheduler {
+
+    override fun schedule(workName: String) {
+        // TODO
+    }
+}
+
+@Module
+abstract class TestWorkScheduleModule {
+
+    @Binds
+    abstract fun bindWorkScheduler(workScheduler: TestWorkScheduler): WorkScheduler
+}

--- a/build-logic/convention/src/main/kotlin/HiltConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/HiltConventionPlugin.kt
@@ -17,6 +17,7 @@
 import com.android.build.gradle.api.AndroidBasePlugin
 import com.teobaranga.monica.implementation
 import com.teobaranga.monica.ksp
+import com.teobaranga.monica.kspTest
 import com.teobaranga.monica.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -29,6 +30,7 @@ class HiltConventionPlugin : Plugin<Project> {
             pluginManager.apply(libs.plugins.ksp.get().pluginId)
             dependencies {
                 ksp(libs.hilt.compiler)
+                kspTest(libs.dagger.compiler)
             }
 
             /** Add support for Android modules, based on [AndroidBasePlugin] */

--- a/build-logic/convention/src/main/kotlin/com/teobaranga/monica/ProjectExtensions.kt
+++ b/build-logic/convention/src/main/kotlin/com/teobaranga/monica/ProjectExtensions.kt
@@ -39,6 +39,10 @@ fun DependencyHandlerScope.ksp(dependencyNotation: Any) {
     add("ksp", dependencyNotation)
 }
 
+fun DependencyHandlerScope.kspTest(dependencyNotation: Any) {
+    add("kspTest", dependencyNotation)
+}
+
 fun DependencyHandlerScope.coreLibraryDesugaring(dependencyNotation: Any) {
     add("coreLibraryDesugaring", dependencyNotation)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,3 +40,7 @@ kotlin.code.style=official
 # Use parallel GC for improved performance
 # https://dev.to/cdsap/using-parellgc-for-the-kotlin-process-in-android-builds-2geh
 kotlin.daemon.jvmargs=-Xmx2048m -XX:+UseParallelGC
+
+# Apply KSP only on main source set by default
+# https://kotlinlang.org/docs/ksp-multiplatform.html#avoid-the-ksp-configuration-on-ksp-1-0-1
+ksp.allow.all.target.configuration=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ google-services = "4.4.2"
 hilt-navigation-compose = "1.2.0"
 hilt-work = "1.2.0"
 junit = "4.13.2"
+kotest = "6.0.0.M1"
 kotlinx-coroutines = "1.9.0"
 materialKolor = "2.0.0"
 moshi = "1.15.1"
@@ -37,6 +38,7 @@ retrofit = "2.11.0"
 room = "2.6.1"
 sandwich = "2.0.10"
 timber = "5.0.1"
+turbine = "1.2.0"
 androidx-test-ext-junit = "1.2.1"
 espresso-core = "3.6.1"
 lifecycle = "2.8.7"
@@ -57,6 +59,7 @@ compose-destinations-core = { group = "io.github.raamcosta.compose-destinations"
 compose-destinations-ksp = { group = "io.github.raamcosta.compose-destinations", name = "ksp", version.ref = "compose-destinations" }
 compose-placeholder = { group = "com.eygraber", name = "compose-placeholder-material3", version.ref = "compose-placeholder" }
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
+dagger-compiler = { group = "com.google.dagger", name = "dagger-compiler", version.ref = "hilt" }
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 desugar-jdk-libs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugar-jdk-libs" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
@@ -68,6 +71,7 @@ hilt-core = { group = "com.google.dagger", name = "hilt-core", version.ref = "hi
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hilt-navigation-compose" }
 hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hilt-work" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+kotest-runner-junit5 = { group = "io.kotest", name = "kotest-runner-junit5", version.ref = "kotest" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 material-kolor = { module = "com.materialkolor:material-kolor", version.ref = "materialKolor" }
@@ -84,6 +88,7 @@ room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "
 sandwich = { group = "com.github.skydoves", name = "sandwich", version.ref = "sandwich" }
 sandwich-retrofit = { group = "com.github.skydoves", name = "sandwich-retrofit", version.ref = "sandwich" }
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
+turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
 lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }


### PR DESCRIPTION
This is an exploration of BDD unit testing as described in this talk: https://www.droidcon.com/2023/04/06/the-unit-testing-diet-start-with-bdd-and-do-not-mock/

The `SetupViewModelTest` has been converted to a BDD unit test using Kotest and Turbine. Many steps were required to get there:

- Used Dagger 2 to provide the dependencies of the ViewModel, using real implementations unless needed otherwise. Room DAOs, WorkManager, and the Retrofit API are some examples of frameworks that needed fake implementations. A `WorkScheduler` abstraction was added to avoid depending on real `WorkManager` classes.
- Disabled running Hilt processing in unit tests by using `ksp.allow.all.target.configuration=false` because it's not useful there - Dagger 2 is enough.