### PR TITLE
fix(activities): remove sync skip logic

### DIFF
--- a/app/src/main/java/com/teobaranga/monica/activities/data/ContactActivitiesSynchronizer.kt
+++ b/app/src/main/java/com/teobaranga/monica/activities/data/ContactActivitiesSynchronizer.kt
@@ -25,9 +25,6 @@ class ContactActivitiesSynchronizer @AssistedInject constructor(
     override val syncState = MutableStateFlow(Synchronizer.State.IDLE)
 
     override suspend fun sync() {
-        if (!isSyncEnabled) {
-            return
-        }
 
         syncState.value = Synchronizer.State.REFRESHING
 
@@ -88,19 +85,11 @@ class ContactActivitiesSynchronizer @AssistedInject constructor(
         contactActivitiesDao.delete(activityIds)
 
         syncState.value = Synchronizer.State.IDLE
-
-        isSyncEnabled = false
     }
 
     @AssistedFactory
     interface Factory {
         fun create(contactId: Int): ContactActivitiesSynchronizer
-    }
-
-    companion object {
-
-        // TODO: this doesn't make much sense, this Synchronizer is not a singleton
-        private var isSyncEnabled = true
     }
 }
 


### PR DESCRIPTION
This indeed didn't make sense. Because `isSyncEnabled` was a static property, it just meant that no activity syncs were done post the first one.