### PR TITLE
allow building without google-services.json

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+import com.google.gms.googleservices.GoogleServicesPlugin
 
 plugins {
     alias(libs.plugins.monica.android.application)
@@ -71,6 +72,10 @@ android {
             test.systemProperties["robolectric.logging.enabled"] = "true"
         }
     }
+}
+
+googleServices {
+    missingGoogleServicesStrategy = GoogleServicesPlugin.MissingGoogleServicesStrategy.WARN
 }
 
 dependencies {


### PR DESCRIPTION
Changes the missing file handling strategy from an error to a warning to allow building the app.

Should fix #389 