### PR TITLE
fix kotlin inject plugin configuration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -180,6 +180,6 @@ detekt {
 
 monica {
     inject {
-        injectIn = InjectHandler.Target.SEPARATE
+        injectIn.set(InjectHandler.Target.SEPARATE)
     }
 }

--- a/build-logic/convention/src/main/kotlin/com/teobaranga/monica/MonicaExtension.kt
+++ b/build-logic/convention/src/main/kotlin/com/teobaranga/monica/MonicaExtension.kt
@@ -1,10 +1,12 @@
 package com.teobaranga.monica
 
 import org.gradle.api.Action
+import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.findByType
+import org.gradle.kotlin.dsl.property
 import javax.inject.Inject
 
 /**
@@ -42,9 +44,10 @@ open class OptInHandler @Inject constructor() {
     var flowPreview: Boolean = true
 }
 
-open class InjectHandler @Inject constructor() {
+open class InjectHandler @Inject constructor(project: Project) {
 
-    var injectIn: Target = Target.COMMON
+    val injectIn = project.objects.property<Target>()
+        .convention(Target.COMMON)
 
     enum class Target {
 

--- a/build-logic/convention/src/main/kotlin/com/teobaranga/monica/ProjectExtensions.kt
+++ b/build-logic/convention/src/main/kotlin/com/teobaranga/monica/ProjectExtensions.kt
@@ -39,9 +39,3 @@ fun DependencyHandlerScope.testImplementation(dependencyNotation: Any) {
 fun DependencyHandlerScope.coreLibraryDesugaring(dependencyNotation: Any) {
     add("coreLibraryDesugaring", dependencyNotation)
 }
-
-fun <T: Any> DependencyHandler.addAll(configurationName: String, dependencies: Array<T>) {
-    for (dependency in dependencies) {
-        add(configurationName, dependency)
-    }
-}

--- a/feature/configuration/build.gradle.kts
+++ b/feature/configuration/build.gradle.kts
@@ -28,6 +28,6 @@ android {
 
 monica {
     inject {
-        injectIn = InjectHandler.Target.SEPARATE
+        injectIn.set(InjectHandler.Target.SEPARATE)
     }
 }


### PR DESCRIPTION
avoid using afterEvaluate to set dependencies, instead configure KMP targets as they become available with `all` and turn `injectIn` into a property that can be mapped into a dependency.

Thanks to this blog for the guidance: https://melix.github.io/blog/2022/03/gradle-conditional-dependencies.html