### PR TITLE
use Compose Multiplatform 1.9.0-alpha02

### DIFF
--- a/build-logic/convention/src/main/kotlin/ComposeMultiplatformConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/ComposeMultiplatformConventionPlugin.kt
@@ -32,24 +32,16 @@ class ComposeMultiplatformConventionPlugin : Plugin<Project> {
                         dependencies {
                             implementation(project(":core:datetime"))
 
-                            implementation(libs.jetbrains.compose.material3.get().module.toString()) {
-                                // Enforce a downgrade of Jetbrains Compose Material3. The latest version doesn't have
-                                // access to newer Material3 API that this app added before CMP, eg. OutlinedTextField
-                                // with TextFieldState.
-                                version {
-                                    strictly(libs.jetbrains.compose.material3.get().version!!)
-                                }
-                            }
                             implementation(libs.jetbrains.compose.ui.backhandler)
                             implementation(libs.jetbrains.lifecycle.runtime.compose)
+                            implementation(libs.jetbrains.navigation)
                             implementation(compose.ui)
                             implementation(compose.components.resources)
                             implementation(compose.components.uiToolingPreview)
+                            implementation(compose.material3)
                             implementation(compose.materialIconsExtended)
                             implementation(compose.runtime)
                             implementation(compose.foundation)
-
-                            implementation(libs.jetbrains.navigation)
                         }
                     }
                     afterEvaluate {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ crashlytics = "3.0.4"
 dependency-analysis = "2.18.0"
 detekt = "1.23.8"
 google-services = "4.4.2"
-jetbrains-compose = "1.8.1"
+jetbrains-compose = "1.9.0-alpha02"
 jetbrains-lifecycle = "2.9.0"
 ksp = "2.1.21-2.0.2"
 kotlin = "2.1.21"
@@ -67,8 +67,6 @@ desugar-jdk-libs = { group = "com.android.tools", name = "desugar_jdk_libs", ver
 detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
-# https://github.com/JetBrains/compose-multiplatform-core/pull/1868
-jetbrains-compose-material3 = { module = "org.jetbrains.compose.material3:material3", version = "1.8.0-alpha03" }
 jetbrains-compose-ui-backhandler = { module = "org.jetbrains.compose.ui:ui-backhandler", version = "1.8.1" }
 jetbrains-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "jetbrains-lifecycle" }
 jetbrains-navigation = { group = "org.jetbrains.androidx.navigation", name = "navigation-compose", version.ref = "jetbrains-navigation" }


### PR DESCRIPTION
This will drop the need to enforce an older alpha version