### PR TITLE
fix pagination bug due to incorrect API usage

### DIFF
--- a/app/src/commonMain/kotlin/com/teobaranga/monica/contacts/list/ContactsScreen.kt
+++ b/app/src/commonMain/kotlin/com/teobaranga/monica/contacts/list/ContactsScreen.kt
@@ -45,6 +45,7 @@ import com.teobaranga.monica.contact.Contact
 import com.teobaranga.monica.contacts.detail.ContactDetailRoute
 import com.teobaranga.monica.contacts.edit.ContactEditRoute
 import com.teobaranga.monica.core.paging.collectAsLazyPagingItems
+import com.teobaranga.monica.core.paging.itemKey
 import com.teobaranga.monica.core.ui.navigation.LocalNavigator
 import com.teobaranga.monica.core.ui.plus
 import com.teobaranga.monica.core.ui.pulltorefresh.MonicaPullToRefreshBox
@@ -180,11 +181,12 @@ private fun ContactsScreen(
                         is LoadState.NotLoading,
                         -> {
                             items(
-                                items = contacts.itemSnapshotList,
-                                key = { contact ->
-                                    contact?.id ?: Int.MIN_VALUE
+                                count = contacts.itemCount,
+                                key = contacts.itemKey { contact ->
+                                    contact.id
                                 },
-                            ) { contact ->
+                            ) { index ->
+                                val contact = contacts[index]
                                 if (contact != null) {
                                     ContactItem(
                                         modifier = Modifier

--- a/app/src/commonMain/kotlin/com/teobaranga/monica/dashboard/DashboardScreen.kt
+++ b/app/src/commonMain/kotlin/com/teobaranga/monica/dashboard/DashboardScreen.kt
@@ -39,6 +39,7 @@ import com.teobaranga.monica.contact.Contact
 import com.teobaranga.monica.contacts.detail.ContactDetailRoute
 import com.teobaranga.monica.core.paging.LazyPagingItems
 import com.teobaranga.monica.core.paging.collectAsLazyPagingItems
+import com.teobaranga.monica.core.paging.itemKey
 import com.teobaranga.monica.core.ui.navigation.LocalNavigator
 import com.teobaranga.monica.core.ui.searchbar.MonicaSearchBar
 import com.teobaranga.monica.core.ui.theme.MonicaTheme
@@ -175,12 +176,9 @@ private fun RecentContactsSection(
                 -> {
                     items(
                         count = recentContacts.itemCount,
-                        key = {
-                            val contact = recentContacts[it]
-                            contact?.id ?: Int.MIN_VALUE
-                        },
-                    ) { contactId ->
-                        val contact = recentContacts[contactId]
+                        key = recentContacts.itemKey { contact -> contact.id },
+                    ) { index ->
+                        val contact = recentContacts[index]
                         if (contact != null) {
                             UserAvatar(
                                 modifier = Modifier

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -20,6 +20,8 @@ kotlin {
                 implementation(libs.kotlinx.coroutines.core)
                 implementation(libs.kotlinx.serialization)
 
+                implementation(libs.kmlogging)
+
                 implementation(libs.paging.common)
             }
         }

--- a/core/data/src/commonMain/kotlin/com/teobaranga/monica/core/data/local/RoomPagingSource.kt
+++ b/core/data/src/commonMain/kotlin/com/teobaranga/monica/core/data/local/RoomPagingSource.kt
@@ -2,6 +2,7 @@ package com.teobaranga.monica.core.data.local
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
+import com.diamondedge.logging.logging
 import com.teobaranga.monica.core.data.sync.Synchronizer
 import com.teobaranga.monica.core.dispatcher.Dispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -36,6 +37,8 @@ abstract class RoomPagingSource<T : Any>(
         // Start paging with the STARTING_KEY if this is the first load
         val start = params.key ?: STARTING_KEY
 
+        log.d { "${this}: Loading with params ${params}, key: $start" }
+
         val entries = getEntries(start, params)
 
         return LoadResult.Page(
@@ -50,6 +53,8 @@ abstract class RoomPagingSource<T : Any>(
         return state.anchorPosition?.let { anchorPosition ->
             val anchorPage = state.closestPageToPosition(anchorPosition)
             anchorPage?.prevKey?.plus(1) ?: anchorPage?.nextKey?.minus(1)
+        }.also {
+            log.d { "${this}: Refresh key $it" }
         }
     }
 
@@ -57,4 +62,9 @@ abstract class RoomPagingSource<T : Any>(
      * @param start Effectively the page index, starting from 0.
      */
     protected abstract suspend fun getEntries(start: Int, params: LoadParams<Int>): List<T>
+
+    companion object {
+
+        private val log = logging()
+    }
 }

--- a/core/paging/src/androidMain/kotlin/com/teobaranga/monica/core/paging/PagingPlaceholderKey.android.kt
+++ b/core/paging/src/androidMain/kotlin/com/teobaranga/monica/core/paging/PagingPlaceholderKey.android.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.teobaranga.monica.core.paging
+
+import android.os.Parcel
+import android.os.Parcelable
+
+internal actual fun getPagingPlaceholderKey(index: Int): Any = PagingPlaceholderKey(index)
+
+private data class PagingPlaceholderKey(private val index: Int) : Parcelable {
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeInt(index)
+    }
+
+    override fun describeContents(): Int {
+        return 0
+    }
+
+    companion object {
+        @Suppress("unused")
+        @JvmField
+        val CREATOR: Parcelable.Creator<PagingPlaceholderKey> =
+            object : Parcelable.Creator<PagingPlaceholderKey> {
+                override fun createFromParcel(parcel: Parcel) =
+                    PagingPlaceholderKey(parcel.readInt())
+
+                override fun newArray(size: Int) = arrayOfNulls<PagingPlaceholderKey?>(size)
+            }
+    }
+}

--- a/core/paging/src/commonMain/kotlin/com/teobaranga/monica/core/paging/LazyFoundationExtensions.kt
+++ b/core/paging/src/commonMain/kotlin/com/teobaranga/monica/core/paging/LazyFoundationExtensions.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.teobaranga.monica.core.paging
+
+import androidx.compose.foundation.lazy.grid.LazyGridScope
+import androidx.paging.PagingConfig
+import kotlin.jvm.JvmSuppressWildcards
+
+/**
+ * Returns a factory of stable and unique keys representing the item.
+ *
+ * Keys are generated with the key lambda that is passed in. If null is passed in, keys will default
+ * to a placeholder key. If [PagingConfig.enablePlaceholders] is true, LazyPagingItems may return
+ * null items. Null items will also automatically default to a placeholder key.
+ *
+ * This factory can be applied to Lazy foundations such as [LazyGridScope.items] or Pagers.
+ *
+ * @param [key] a factory of stable and unique keys representing the item. Using the same key for
+ *   multiple items in the list is not allowed. Type of the key should be saveable via Bundle on
+ *   Android. When you specify the key the scroll position will be maintained based on the key,
+ *   which means if you add/remove items before the current visible item the item with the given key
+ *   will be kept as the first visible one.
+ */
+fun <T : Any> LazyPagingItems<T>.itemKey(
+    key: ((item: @JvmSuppressWildcards T) -> Any)? = null,
+): (index: Int) -> Any {
+    return { index ->
+        if (key == null) {
+            getPagingPlaceholderKey(index)
+        } else {
+            val item = peek(index)
+            if (item == null) getPagingPlaceholderKey(index) else key(item)
+        }
+    }
+}
+
+/**
+ * Returns a factory for the content type of the item.
+ *
+ * ContentTypes are generated with the contentType lambda that is passed in. If null is passed in,
+ * contentType of all items will default to `null`. If [PagingConfig.enablePlaceholders] is true,
+ * LazyPagingItems may return null items. Null items will automatically default to placeholder
+ * contentType.
+ *
+ * This factory can be applied to Lazy foundations such as [LazyGridScope.items] or Pagers.
+ *
+ * @param [contentType] a factory of the content types for the item. The item compositions of the
+ *   same type could be reused more efficiently. Note that null is a valid type and items of such
+ *   type will be considered compatible.
+ */
+fun <T : Any> LazyPagingItems<T>.itemContentType(
+    contentType: ((item: @JvmSuppressWildcards T) -> Any?)? = null,
+): (index: Int) -> Any? {
+    return { index ->
+        if (contentType == null) {
+            null
+        } else {
+            val item = peek(index)
+            if (item == null) PagingPlaceholderContentType else contentType(item)
+        }
+    }
+}

--- a/core/paging/src/commonMain/kotlin/com/teobaranga/monica/core/paging/LazyPagingItems.kt
+++ b/core/paging/src/commonMain/kotlin/com/teobaranga/monica/core/paging/LazyPagingItems.kt
@@ -26,9 +26,13 @@ import androidx.paging.CombinedLoadStates
 import androidx.paging.ItemSnapshotList
 import androidx.paging.LoadState
 import androidx.paging.LoadStates
+import androidx.paging.LoadType
+import androidx.paging.LoadType.REFRESH
 import androidx.paging.PagingData
 import androidx.paging.PagingDataEvent
 import androidx.paging.PagingDataPresenter
+import androidx.paging.PagingSource
+import androidx.paging.RemoteMediator
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -47,15 +51,13 @@ import kotlin.coroutines.EmptyCoroutineContext
  * Previewing [LazyPagingItems] is supported on a list of mock data. See sample for how to preview
  * mock data.
  *
- * @sample androidx.paging.compose.samples.PagingPreview
- *
  * @param T the type of value used by [PagingData].
  */
 public class LazyPagingItems<T : Any> internal constructor(
     /**
      * the [Flow] object which contains a stream of [PagingData] elements.
      */
-    private val flow: Flow<PagingData<T>>
+    private val flow: Flow<PagingData<T>>,
 ) {
     private val mainDispatcher = uiDispatcher()
 
@@ -191,14 +193,12 @@ private val InitialLoadStates = LoadStates(
  * instance. The [LazyPagingItems] instance can be used for lazy foundations such as
  * [LazyListScope.items] in order to display the data obtained from a [Flow] of [PagingData].
  *
- * @sample androidx.paging.compose.samples.PagingBackendSample
- *
  * @param context the [CoroutineContext] to perform the collection of [PagingData]
  * and [CombinedLoadStates].
  */
 @Composable
-public fun <T : Any> Flow<PagingData<T>>.collectAsLazyPagingItems(
-    context: CoroutineContext = EmptyCoroutineContext
+fun <T : Any> Flow<PagingData<T>>.collectAsLazyPagingItems(
+    context: CoroutineContext = EmptyCoroutineContext,
 ): LazyPagingItems<T> {
 
     val lazyPagingItems = remember(this) { LazyPagingItems(this) }

--- a/core/paging/src/commonMain/kotlin/com/teobaranga/monica/core/paging/PagingPlaceholders.kt
+++ b/core/paging/src/commonMain/kotlin/com/teobaranga/monica/core/paging/PagingPlaceholders.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.teobaranga.monica.core.paging
+
+internal expect fun getPagingPlaceholderKey(index: Int): Any
+
+internal object PagingPlaceholderContentType

--- a/core/paging/src/iosMain/kotlin/com/teobaranga/monica/core/paging/PagingPlaceholderKey.ios.kt
+++ b/core/paging/src/iosMain/kotlin/com/teobaranga/monica/core/paging/PagingPlaceholderKey.ios.kt
@@ -1,0 +1,5 @@
+package com.teobaranga.monica.core.paging
+
+internal actual fun getPagingPlaceholderKey(index: Int): Any = PagingPlaceholderKey(index)
+
+private data class PagingPlaceholderKey(private val index: Int)

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -5,6 +5,14 @@ plugins {
 
 kotlin {
     androidTarget()
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                implementation(libs.kmlogging)
+            }
+        }
+    }
 }
 
 android {

--- a/core/ui/src/commonMain/kotlin/com/teobaranga/monica/core/ui/datetime/LocalDateTimeFormatter.kt
+++ b/core/ui/src/commonMain/kotlin/com/teobaranga/monica/core/ui/datetime/LocalDateTimeFormatter.kt
@@ -19,6 +19,7 @@ enum class DateFormatStyle {
 expect class LocalDateFormatter(
     locale: PlatformLocale,
     dateFormatStyle: DateFormatStyle = DateFormatStyle.LONG,
+    includeDay: Boolean = true,
     includeYear: Boolean = true,
 ) {
     fun format(date: LocalDate): String
@@ -33,10 +34,16 @@ expect class LocalDateFormatter(
 @Composable
 fun rememberLocalizedDateFormatter(
     dateStyle: DateFormatStyle = DateFormatStyle.LONG,
+    includeDay: Boolean = true,
     includeYear: Boolean = true,
 ): LocalDateFormatter {
     val locale = Locale.current.platformLocale
     return remember(locale, dateStyle, includeYear) {
-        LocalDateFormatter(locale, dateStyle, includeYear)
+        LocalDateFormatter(
+            locale = locale,
+            dateFormatStyle = dateStyle,
+            includeDay = includeDay,
+            includeYear = includeYear,
+        )
     }
 }

--- a/core/ui/src/iosMain/kotlin/com/teobaranga/monica/core/ui/datetime/LocalDateFormatter.kt
+++ b/core/ui/src/iosMain/kotlin/com/teobaranga/monica/core/ui/datetime/LocalDateFormatter.kt
@@ -15,6 +15,7 @@ import platform.Foundation.NSDateFormatter
 actual class LocalDateFormatter actual constructor(
     private val locale: PlatformLocale,
     private val dateFormatStyle: DateFormatStyle,
+    private val includeDay: Boolean,
     private val includeYear: Boolean,
 ) {
     actual fun format(date: LocalDate): String {

--- a/core/ui/src/jvmMain/kotlin/com/teobaranga/monica/core/ui/datetime/LocalDateFormatter.jvm.kt
+++ b/core/ui/src/jvmMain/kotlin/com/teobaranga/monica/core/ui/datetime/LocalDateFormatter.jvm.kt
@@ -18,6 +18,7 @@ import java.time.format.TextStyle
 actual class LocalDateFormatter actual constructor(
     private val locale: PlatformLocale,
     private val dateFormatStyle: DateFormatStyle,
+    includeDay: Boolean,
     includeYear: Boolean,
 ) {
     private val formatter: DateTimeFormatter
@@ -29,18 +30,24 @@ actual class LocalDateFormatter actual constructor(
             DateFormatStyle.LONG -> FormatStyle.LONG
             DateFormatStyle.FULL -> FormatStyle.FULL
         }
-        var format = DateTimeFormatterBuilder.getLocalizedDateTimePattern(
+        var pattern = DateTimeFormatterBuilder.getLocalizedDateTimePattern(
             /* dateStyle = */ dateStyle,
             /* timeStyle = */ null,
             /* chrono = */ Chronology.ofLocale(locale),
             /* locale = */ locale,
         )
         if (!includeYear) {
-            format = format
+            pattern = pattern
                 .replace("(,*|\'de\') [yY]+$".toRegex(), "")
                 .trim()
         }
-        formatter = DateTimeFormatter.ofPattern(format)
+        if (!includeDay) {
+            pattern = pattern
+                .replace(" *[dD]".toRegex(), "")
+                .replace("E*".toRegex(), "")
+                .trim(' ', ',')
+        }
+        formatter = DateTimeFormatter.ofPattern(pattern)
     }
 
     actual fun format(date: LocalDate): String {

--- a/feature/journal/src/commonMain/kotlin/com/teobaranga/monica/journal/list/ui/JournalEntryListScreen.kt
+++ b/feature/journal/src/commonMain/kotlin/com/teobaranga/monica/journal/list/ui/JournalEntryListScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -35,6 +34,8 @@ import androidx.paging.PagingData
 import com.teobaranga.monica.core.datetime.LocalSystemClock
 import com.teobaranga.monica.core.paging.LazyPagingItems
 import com.teobaranga.monica.core.paging.collectAsLazyPagingItems
+import com.teobaranga.monica.core.paging.itemContentType
+import com.teobaranga.monica.core.paging.itemKey
 import com.teobaranga.monica.core.ui.datetime.DateFormatStyle
 import com.teobaranga.monica.core.ui.datetime.rememberLocalizedDateFormatter
 import com.teobaranga.monica.core.ui.plus
@@ -49,6 +50,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.YearMonth
 import kotlinx.datetime.todayIn
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import kotlin.random.Random
 
 @Composable
 fun JournalEntryListScreen(
@@ -134,9 +136,9 @@ private fun LazyListScope.journalEntryListItems(
     lazyItems: LazyPagingItems<JournalEntryListItem>,
     onEntryClick: (id: Int) -> Unit,
 ) {
-    itemsIndexed(
-        items = lazyItems.itemSnapshotList,
-        key = { index, journalEntry ->
+    items(
+        count = lazyItems.itemCount,
+        key = lazyItems.itemKey { journalEntry ->
             when (journalEntry) {
                 is JournalEntryListItem.Entry -> journalEntry.id
                 is JournalEntryListItem.SectionTitle -> buildString {
@@ -147,19 +149,18 @@ private fun LazyListScope.journalEntryListItems(
                     append(journalEntry.month)
                 }
 
-                is JournalEntryListItem.Divider -> "divider_$index"
-                null -> Int.MIN_VALUE
+                is JournalEntryListItem.Divider -> "divider_${Random.nextInt()}"
             }
         },
-        contentType = { index, journalEntryItem ->
+        contentType = lazyItems.itemContentType { journalEntryItem ->
             when (journalEntryItem) {
                 is JournalEntryListItem.Entry -> "entry"
                 is JournalEntryListItem.SectionTitle -> "section_title"
                 is JournalEntryListItem.Divider -> "divider"
-                null -> "null"
             }
         },
-    ) { index, journalEntry ->
+    ) { index ->
+        val journalEntry = lazyItems[index]
         JournalEntryListItem(
             journalEntry = journalEntry,
             onEntryClick = onEntryClick,
@@ -186,7 +187,7 @@ private fun LazyItemScope.JournalEntryListItem(
         }
 
         is JournalEntryListItem.SectionTitle -> {
-            val formatter = rememberLocalizedDateFormatter(dateStyle = DateFormatStyle.FULL)
+            val formatter = rememberLocalizedDateFormatter(dateStyle = DateFormatStyle.FULL, includeDay = false)
             Text(
                 modifier = Modifier
                     .padding(vertical = 16.dp)


### PR DESCRIPTION
When the app migrated to the multiplatform paging library, a bug was introduced.

Because the way the data (journal entries, contacts, etc.) was loaded in Compose, without using the Paging library `itemKey` and `itemContentType` function, only the first 15 results were returned.

Using the right APIs fixed the problem and now all results are returned correctly.

Additionally, the YearMonth date formatting is now fixed on Android by making sure any day information from the pattern is removed.