### PR TITLE
fix time zone handling

### DIFF
--- a/app/src/androidHostTest/kotlin/com/teobaranga/monica/contacts/Contacts.kt
+++ b/app/src/androidHostTest/kotlin/com/teobaranga/monica/contacts/Contacts.kt
@@ -5,6 +5,7 @@ import com.teobaranga.monica.contacts.data.ContactResponse
 import com.teobaranga.monica.contacts.data.CreateContactRequest
 import com.teobaranga.monica.core.data.sync.SyncStatus
 import com.teobaranga.monica.genders.data.genderMale
+import kotlinx.datetime.LocalDate
 import kotlin.time.Instant
 
 const val TEST_CONTACT_ID = 123
@@ -89,7 +90,7 @@ fun ContactEntity.toCreateRequest(
 
 fun ContactEntity.toResponse(
     gender: String? = null,
-    birthday: Instant? = birthdate?.date,
+    birthday: LocalDate? = birthdate?.date,
     birthdateIsAgeBased: Boolean = false,
     birthdateIsYearUnknown: Boolean = false,
 ): ContactResponse {

--- a/app/src/androidHostTest/kotlin/com/teobaranga/monica/contacts/edit/ContactBirthdayTest.kt
+++ b/app/src/androidHostTest/kotlin/com/teobaranga/monica/contacts/edit/ContactBirthdayTest.kt
@@ -27,7 +27,6 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlinx.datetime.number
 import kotlinx.datetime.toLocalDateTime
-import kotlin.time.Instant
 
 class ContactBirthdayTest : BehaviorSpec(
     {
@@ -47,7 +46,11 @@ class ContactBirthdayTest : BehaviorSpec(
         }
 
         Given("unknown year birthday") {
-            val expectedBirthday = Instant.parse("${testNow.toLocalDateTime(testTimeZone).year}-06-01T00:00:00.000Z")
+            val expectedBirthday = LocalDate(
+                year = testNow.toLocalDateTime(testTimeZone).year,
+                month = Month.JUNE,
+                day = 1,
+            )
             coEvery {
                 contactApi.updateContact(
                     id = validContact.contactId,
@@ -94,7 +97,11 @@ class ContactBirthdayTest : BehaviorSpec(
             val currentYear = testNow.toLocalDateTime(testTimeZone).year
             val age = 18
             val birthdayYear = currentYear - age
-            val expectedBirthday = Instant.parse("${birthdayYear}-01-01T00:00:00.000Z")
+            val expectedBirthday = LocalDate(
+                year = birthdayYear,
+                month = Month.JANUARY,
+                day = 1,
+            )
             coEvery {
                 contactApi.updateContact(
                     id = validContact.contactId,
@@ -138,7 +145,11 @@ class ContactBirthdayTest : BehaviorSpec(
         }
 
         Given("exact birthday") {
-            val expectedBirthday = Instant.parse("1995-02-01T00:00:00.000Z")
+            val expectedBirthday = LocalDate(
+                year = 1995,
+                month = Month.FEBRUARY,
+                day = 1,
+            )
             coEvery {
                 contactApi.updateContact(
                     id = validContact.contactId,

--- a/app/src/androidHostTest/kotlin/com/teobaranga/monica/contacts/edit/ContactEditViewModelTest.kt
+++ b/app/src/androidHostTest/kotlin/com/teobaranga/monica/contacts/edit/ContactEditViewModelTest.kt
@@ -27,9 +27,12 @@ import io.mockk.every
 import kotlinx.coroutines.flow.first
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
-import kotlin.time.Instant
 
-private val birthdate = Instant.parse("2010-06-01T22:19:44.475Z")
+private val birthdate = LocalDate(
+    year = 2010,
+    month = Month.JUNE,
+    day = 1,
+)
 
 class ContactEditViewModelTest : BehaviorSpec(
     {

--- a/app/src/commonMain/kotlin/com/teobaranga/monica/contacts/data/ContactEntity.kt
+++ b/app/src/commonMain/kotlin/com/teobaranga/monica/contacts/data/ContactEntity.kt
@@ -6,6 +6,7 @@ import androidx.room.PrimaryKey
 import com.teobaranga.monica.contact.Contact
 import com.teobaranga.monica.contacts.list.userAvatar
 import com.teobaranga.monica.core.data.sync.SyncStatus
+import kotlinx.datetime.LocalDate
 import kotlin.time.Instant
 
 @Entity(tableName = "contacts")
@@ -48,7 +49,7 @@ data class ContactEntity(
     data class Birthdate(
         val isAgeBased: Boolean,
         val isYearUnknown: Boolean,
-        val date: Instant,
+        val date: LocalDate,
     )
 }
 

--- a/app/src/commonMain/kotlin/com/teobaranga/monica/contacts/data/ContactRequestMapper.kt
+++ b/app/src/commonMain/kotlin/com/teobaranga/monica/contacts/data/ContactRequestMapper.kt
@@ -1,16 +1,13 @@
 package com.teobaranga.monica.contacts.data
 
-import kotlinx.datetime.TimeZone
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.number
-import kotlinx.datetime.toLocalDateTime
 import kotlinx.datetime.yearsUntil
 import me.tatarka.inject.annotations.Inject
-import kotlin.time.Clock
 
 @Inject
 class ContactRequestMapper(
-    private val clock: Clock,
-    private val timeZone: TimeZone,
+    private val nowDate: () -> LocalDate,
 ) {
 
     operator fun invoke(entity: ContactEntity): CreateContactRequest {
@@ -35,7 +32,7 @@ class ContactRequestMapper(
             if (isAgeBased) {
                 null
             } else {
-                date.toLocalDateTime(timeZone).day
+                date.day
             }
         }
     }
@@ -45,21 +42,21 @@ class ContactRequestMapper(
             if (isAgeBased) {
                 null
             } else {
-                date.toLocalDateTime(timeZone).month.number
+                date.month.number
             }
         }
     }
 
     private fun ContactEntity.getBirthdateYear(): Int? {
         return birthdate?.run {
-            date.toLocalDateTime(timeZone).year.takeIf { !isYearUnknown }
+            date.year.takeIf { !isYearUnknown }
         }
     }
 
     private fun ContactEntity.getBirthdateAge(): Int? {
         return birthdate?.run {
             if (isAgeBased) {
-                date.yearsUntil(clock.now(), timeZone)
+                date.yearsUntil(nowDate())
             } else {
                 null
             }

--- a/app/src/commonMain/kotlin/com/teobaranga/monica/contacts/data/ContactResponse.kt
+++ b/app/src/commonMain/kotlin/com/teobaranga/monica/contacts/data/ContactResponse.kt
@@ -1,5 +1,7 @@
 package com.teobaranga.monica.contacts.data
 
+import com.teobaranga.monica.core.datetime.serializer.MonicaLocalDateSerializer
+import kotlinx.datetime.LocalDate
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.time.Instant
@@ -52,7 +54,8 @@ data class ContactResponse(
                 @SerialName("is_year_unknown")
                 val isYearUnknown: Boolean?,
                 @SerialName("date")
-                val date: Instant?,
+                @Serializable(with = MonicaLocalDateSerializer::class)
+                val date: LocalDate?,
             )
         }
     }

--- a/app/src/commonMain/kotlin/com/teobaranga/monica/contacts/data/ContactSynchronizer.kt
+++ b/app/src/commonMain/kotlin/com/teobaranga/monica/contacts/data/ContactSynchronizer.kt
@@ -1,6 +1,7 @@
 package com.teobaranga.monica.contacts.data
 
 import com.diamondedge.logging.logging
+import com.skydoves.sandwich.ApiResponse
 import com.skydoves.sandwich.getOrElse
 import com.skydoves.sandwich.message
 import com.skydoves.sandwich.onFailure
@@ -48,7 +49,14 @@ class ContactSynchronizer(
         while (nextPage != null) {
             val contactsResponse = contactApi.getContacts(page = nextPage, sort = "-updated_at")
                 .onFailure {
-                    log.e { "Error while loading contacts: ${message()}" }
+                    when (this) {
+                        is ApiResponse.Failure.Error -> {
+                            log.e { "Error while loading contacts: ${message()}" }
+                        }
+                        is ApiResponse.Failure.Exception -> {
+                            log.e(throwable) { "Error while loading contacts" }
+                        }
+                    }
                 }
                 .getOrElse {
                     syncState.value = Synchronizer.State.IDLE

--- a/app/src/commonMain/kotlin/com/teobaranga/monica/contacts/edit/birthday/BirthdayMapper.kt
+++ b/app/src/commonMain/kotlin/com/teobaranga/monica/contacts/edit/birthday/BirthdayMapper.kt
@@ -5,38 +5,29 @@ import com.teobaranga.monica.contacts.ui.Birthday
 import com.teobaranga.monica.core.datetime.MonthDay
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.atStartOfDayIn
-import kotlinx.datetime.format.DateTimeComponents
-import kotlinx.datetime.format.format
 import kotlinx.datetime.minus
-import kotlinx.datetime.toLocalDateTime
-import kotlinx.datetime.todayIn
+import kotlinx.datetime.number
 import kotlinx.datetime.yearsUntil
 import me.tatarka.inject.annotations.Inject
-import kotlin.time.Clock
-import kotlin.time.Instant
 
 @Inject
 class BirthdayMapper(
-    private val clock: Clock,
-    private val timeZone: TimeZone,
     private val getNowLocalDate: () -> LocalDate,
 ) {
 
     fun toUi(birthdate: ContactEntity.Birthdate): Birthday {
         return when {
             birthdate.isAgeBased -> {
-                Birthday.AgeBased(birthdate.date.yearsUntil(clock.now(), timeZone))
+                Birthday.AgeBased(birthdate.date.yearsUntil(getNowLocalDate()))
             }
 
             birthdate.isYearUnknown -> {
-                val localDate = birthdate.date.toLocalDateTime(timeZone).date
+                val localDate = birthdate.date
                 Birthday.UnknownYear(MonthDay.from(localDate))
             }
 
             else -> {
-                Birthday.Full(birthdate.date.toLocalDateTime(timeZone).date)
+                Birthday.Full(birthdate.date)
             }
         }
     }
@@ -47,35 +38,23 @@ class BirthdayMapper(
                 isAgeBased = true,
                 isYearUnknown = false,
                 date = getNowLocalDate()
-                    .minus(birthday.age.toLong(), DateTimeUnit.YEAR)
-                    .atStartOfDayIn(timeZone),
+                    .minus(birthday.age.toLong(), DateTimeUnit.YEAR),
             )
 
             is Birthday.UnknownYear -> ContactEntity.Birthdate(
                 isAgeBased = false,
                 isYearUnknown = true,
-                date = run {
-                    val format = DateTimeComponents.Formats.ISO_DATE_TIME_OFFSET.format {
-                        month = birthday.monthDay.month
-                        day = birthday.monthDay.dayOfMonth
-                        // When the year is unknown, the provided year can be anything
-                        year = clock.todayIn(timeZone).year
-                        hour = 0
-                        minute = 0
-                        second = 0
-                        nanosecond = 0
-                        offsetHours = 0
-                        offsetMinutesOfHour = 0
-                        offsetSecondsOfMinute = 0
-                    }
-                    Instant.parse(format)
-                },
+                date = LocalDate(
+                    year = getNowLocalDate().year,
+                    month = birthday.monthDay.month.number,
+                    day = birthday.monthDay.dayOfMonth,
+                ),
             )
 
             is Birthday.Full -> ContactEntity.Birthdate(
                 isAgeBased = false,
                 isYearUnknown = false,
-                date = birthday.date.atStartOfDayIn(timeZone),
+                date = birthday.date,
             )
         }
     }

--- a/core/datetime/build.gradle.kts
+++ b/core/datetime/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.monica.kmp)
     alias(libs.plugins.monica.kotlin.inject)
+    alias(libs.plugins.kotlinx.serialization)
 }
 
 kotlin {
@@ -14,6 +15,8 @@ kotlin {
 
                 implementation(libs.jetbrains.compose.runtime)
                 api(libs.kotlinx.datetime)
+
+                implementation(libs.kotlinx.serialization)
             }
         }
     }

--- a/core/datetime/src/commonMain/kotlin/com/teobaranga/monica/core/datetime/serializer/MonicaLocalDateSerializer.kt
+++ b/core/datetime/src/commonMain/kotlin/com/teobaranga/monica/core/datetime/serializer/MonicaLocalDateSerializer.kt
@@ -1,0 +1,39 @@
+package com.teobaranga.monica.core.datetime.serializer
+
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlin.time.Instant
+
+/**
+ * Some dates come down from the API with full time and time zone information, even
+ * though they should represent simple local dates. Current examples are birthdays
+ * or activity dates. This custom serializer strips away the time and time zone and
+ * returns the intended local date.
+ */
+object MonicaLocalDateSerializer : KSerializer<LocalDate> {
+
+    private val delegateSerializer = Instant.serializer()
+
+    // Serial names of descriptors should be unique, this is why we advise including app package in the name.
+    override val descriptor = SerialDescriptor(
+        serialName = "com.teobaranga.monica.LocalDate",
+        original = delegateSerializer.descriptor,
+    )
+
+    override fun serialize(encoder: Encoder, value: LocalDate) {
+        val data = value.atStartOfDayIn(TimeZone.UTC)
+        encoder.encodeSerializableValue(delegateSerializer, data)
+    }
+
+    override fun deserialize(decoder: Decoder): LocalDate {
+        val instant = decoder.decodeSerializableValue(delegateSerializer)
+        return instant.toLocalDateTime(TimeZone.UTC).date
+    }
+}

--- a/core/ui/src/commonMain/kotlin/com/teobaranga/monica/core/ui/button/DateButton.kt
+++ b/core/ui/src/commonMain/kotlin/com/teobaranga/monica/core/ui/button/DateButton.kt
@@ -52,7 +52,7 @@ fun DateButton(date: LocalDate, onDateSelect: (LocalDate) -> Unit, modifier: Mod
     if (showDatePickerDialog) {
         val datePickerState = rememberDatePickerState(
             initialSelectedDateMillis = date
-                .atStartOfDayIn(TimeZone.currentSystemDefault())
+                .atStartOfDayIn(TimeZone.UTC)
                 .toEpochMilliseconds(),
         )
         DatePickerDialog(
@@ -61,7 +61,7 @@ fun DateButton(date: LocalDate, onDateSelect: (LocalDate) -> Unit, modifier: Mod
                     onClick = {
                         datePickerState.selectedDateMillis?.let {
                             val date = Instant.fromEpochMilliseconds(it)
-                                .toLocalDateTime(TimeZone.currentSystemDefault())
+                                .toLocalDateTime(TimeZone.UTC)
                                 .date
                             onDateSelect(date)
                         }
@@ -89,7 +89,7 @@ fun DateButton(date: LocalDate, onDateSelect: (LocalDate) -> Unit, modifier: Mod
 private fun PreviewDateButton() {
     MonicaTheme {
         DateButton(
-            date = LocalSystemClock.current.todayIn(TimeZone.currentSystemDefault()),
+            date = LocalSystemClock.current.todayIn(TimeZone.UTC),
             onDateSelect = { },
         )
     }

--- a/feature/journal/src/androidHostTest/kotlin/com/teobaranga/monica/journal/JournalEntryViewModelTest.kt
+++ b/feature/journal/src/androidHostTest/kotlin/com/teobaranga/monica/journal/JournalEntryViewModelTest.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlinx.datetime.TimeZone
-import kotlinx.datetime.atStartOfDayIn
 import kotlinx.datetime.todayIn
 import kotlin.time.Clock
 
@@ -128,7 +127,7 @@ class JournalEntryViewModelTest : BehaviorSpec(
                 } returns ApiResponse.of {
                     JournalEntryResponse(
                         data = validJournalEntry.toResponse(
-                            date = testDate.atStartOfDayIn(TimeZone.UTC),
+                            date = testDate,
                         )
                     )
                 }

--- a/feature/journal/src/androidHostTest/kotlin/com/teobaranga/monica/journal/TestJournal.kt
+++ b/feature/journal/src/androidHostTest/kotlin/com/teobaranga/monica/journal/TestJournal.kt
@@ -24,7 +24,7 @@ val validJournalEntry = JournalEntryEntity(
     syncStatus = SyncStatus.UP_TO_DATE,
 )
 
-fun JournalEntryEntity.toResponse(date: Instant): JournalEntry {
+fun JournalEntryEntity.toResponse(date: LocalDate): JournalEntry {
     return JournalEntry(
         id = id,
         uuid = uuid,

--- a/feature/journal/src/commonMain/kotlin/com/teobaranga/monica/journal/data/JournalEntrySynchronizer.kt
+++ b/feature/journal/src/commonMain/kotlin/com/teobaranga/monica/journal/data/JournalEntrySynchronizer.kt
@@ -15,8 +15,6 @@ import com.teobaranga.monica.journal.data.remote.JournalEntry
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 import me.tatarka.inject.annotations.Inject
 import software.amazon.lastmile.kotlin.inject.anvil.AppScope
 import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
@@ -113,7 +111,7 @@ fun JournalEntry.toEntity(): JournalEntryEntity {
         uuid = uuid,
         title = title,
         post = post,
-        date = date.toLocalDateTime(TimeZone.currentSystemDefault()).date,
+        date = date,
         created = created,
         updated = updated,
         syncStatus = SyncStatus.UP_TO_DATE,

--- a/feature/journal/src/commonMain/kotlin/com/teobaranga/monica/journal/data/remote/JournalEntry.kt
+++ b/feature/journal/src/commonMain/kotlin/com/teobaranga/monica/journal/data/remote/JournalEntry.kt
@@ -2,6 +2,8 @@ package com.teobaranga.monica.journal.data.remote
 
 import com.teobaranga.monica.core.data.adapter.UuidAsString
 import com.teobaranga.monica.core.data.remote.AccountResponse
+import com.teobaranga.monica.core.datetime.serializer.MonicaLocalDateSerializer
+import kotlinx.datetime.LocalDate
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.time.Instant
@@ -19,7 +21,8 @@ data class JournalEntry(
     @SerialName("post")
     val post: String,
     @SerialName("date")
-    val date: Instant,
+    @Serializable(with = MonicaLocalDateSerializer::class)
+    val date: LocalDate,
     @SerialName("created_at")
     val created: Instant,
     @SerialName("updated_at")


### PR DESCRIPTION
Fixes #571 

Birthdays, activities, and journal entry dates would be rendered incorrectly because they took into account the current system time zone. The API returns these with time zone information but this is unnecessary - these types of date don't need time zone information. The fix is to model them with `LocalDate` instead. 